### PR TITLE
Fixed setting of use attribute at JWK endpoint to be OIDC compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2022-05-09
+
+### Changed
+
+- Bugfix for setting use correctly conforming to OpenID Connect Specification
+
 ## [0.1.1] - 2022-05-01
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Full documentation can be found at:
 - [Developer Documentation](https://github.com/H2CK/oidc/wiki#developer-documentation)
 
 	]]></description>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <licence>agpl</licence>
   <author mail="dev@jagel.net" homepage="https://github.com/H2CK/oidc">Thorsten Jagel</author>
   <namespace>OIDCIdentityProvider</namespace>

--- a/lib/Controller/JwksController.php
+++ b/lib/Controller/JwksController.php
@@ -62,7 +62,7 @@ class JwksController extends ApiController {
 	 * @CORS
      * @PublicPage
 	 * @NoCSRFRequired
-     * 
+     *
      * Must be proviced at path:
      * <issuer>//.well-known/openid-configuration
 	 *
@@ -79,22 +79,17 @@ class JwksController extends ApiController {
             // 'deriveKey',  // (derive key)
             // 'deriveBits', // (derive bits not to be used as a key)
         ];
-        
-        $use = [
-            'sig',
-            // 'enc',
-        ];
-        
+
         $oidcKey = [
             'kty' => 'RSA',
-            'use' => $use,
+            'use' => 'sig',
             'key_ops' => $keyOps,
             'alg' => 'RS256',
             'kid' => $this->appConfig->getAppValue('kid'),
             'n' => $this->appConfig->getAppValue('public_key_n'),
             'e' => $this->appConfig->getAppValue('public_key_e'),
         ];
-        
+
         $keys = [
             $oidcKey
         ];
@@ -106,5 +101,5 @@ class JwksController extends ApiController {
 		return new JSONResponse($jwkPayload);
 	}
 
-    
+
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "oidc",
 	"description": "Use Nextcloud as OIDC Identity Provider",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"author": "Thorsten Jagel <dev@jagel.net",
 	"bugs": {
 		"url": "https://github.com/H2CK/oidc/issues"

--- a/tests/Unit/Controller/JwksControllerTest.php
+++ b/tests/Unit/Controller/JwksControllerTest.php
@@ -69,14 +69,9 @@ class JwksControllerTest extends TestCase {
             // 'deriveBits', // (derive bits not to be used as a key)
         ];
 
-        $use = [
-            'sig',
-            // 'enc',
-        ];
-
         $oidcKey = [
             'kty' => 'RSA',
-            'use' => $use,
+            'use' => 'sig',
             'key_ops' => $keyOps,
             'alg' => 'RS256',
             'kid' => $this->appConfig->getAppValue('kid'),


### PR DESCRIPTION
Previously the use attribute was delivered as array. But it must be delivered as plain string with the value sig.