### PR TITLE
URL-encode state variable to preserve extra params

### DIFF
--- a/lib/Controller/LoginRedirectorController.php
+++ b/lib/Controller/LoginRedirectorController.php
@@ -223,9 +223,9 @@ class LoginRedirectorController extends ApiController {
 		$accessToken->setNonce($nonce);
 		$this->accessTokenMapper->insert($accessToken);
 
-		$url = $client->getRedirectUri() . '?code=' . $code . '&state=' . $state;
+		$url = $client->getRedirectUri() . '?code=' . $code . '&state=' . urlencode($state);
 		if (str_contains($client->getRedirectUri(), '?')) {
-			$url = $client->getRedirectUri() . '&code=' . $code . '&state=' . $state;
+			$url = $client->getRedirectUri() . '&code=' . $code . '&state=' . urlencode($state);
 		}
 
 		return new RedirectResponse($url);


### PR DESCRIPTION
This conforms with the use-case for OAuth2-Proxy and should fix #36