### PR TITLE
trim whitespace from redirect uris

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -197,7 +197,7 @@ class SettingsController extends Controller
 
         $redirectUriObj = new RedirectUri();
         $redirectUriObj->setClientId($id);
-        $redirectUriObj->setRedirectUri($redirectUri);
+        $redirectUriObj->setRedirectUri(trim($redirectUri));
         $redirectUriObj = $this->redirectUriMapper->insert($redirectUriObj);
         $clients = $this->clientMapper->getClients();
 
@@ -267,7 +267,7 @@ class SettingsController extends Controller
         $this->logger->debug("Adding Logout Redirect URI " . $redirectUri);
 
         $logoutRedirectUriObj = new LogoutRedirectUri();
-        $logoutRedirectUriObj->setRedirectUri($redirectUri);
+        $logoutRedirectUriObj->setRedirectUri(trim($redirectUri));
         $logoutRedirectUriObj = $this->logoutRedirectUriMapper->insert($logoutRedirectUriObj);
 
         $result = [];


### PR DESCRIPTION
Had to debug a weird redirect uri mismatch after accidentally pasting some whitespace into the "OpenID Connect clients - Redirection URI" UI. I think that's a reasonable mistake to make on the user's side, so it should be handled IMO.