### PR TITLE
Handle access token generation and validation requests via events

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,12 +23,15 @@
  */
 namespace OCA\OIDCIdentityProvider\AppInfo;
 
+use OCA\OIDCIdentityProvider\Event\TokenGenerationRequestEvent;
+use OCA\OIDCIdentityProvider\Event\TokenValidationRequestEvent;
 use OCA\OIDCIdentityProvider\Http\WellKnown\WebFingerHandler;
 use OCA\OIDCIdentityProvider\Http\WellKnown\OIDCDiscoveryHandler;
 use OCA\OIDCIdentityProvider\BasicAuthBackend;
+use OCA\OIDCIdentityProvider\Listener\TokenGenerationRequestListener;
+use OCA\OIDCIdentityProvider\Listener\TokenValidationRequestListener;
 use OCP\AppFramework\App;
 use OC_User;
-use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
@@ -51,6 +54,9 @@ class Application extends App implements IBootstrap {
         $context->registerWellKnownHandler(WebFingerHandler::class);
         // Register OIDCDiscoveryHandler
         $context->registerWellKnownHandler(OIDCDiscoveryHandler::class);
+
+		$context->registerEventListener(TokenValidationRequestEvent::class, TokenValidationRequestListener::class);
+		$context->registerEventListener(TokenGenerationRequestEvent::class, TokenGenerationRequestListener::class);
 
         $this->backend = $this->getContainer()->get(BasicAuthBackend::class);
         OC_User::useBackend($this->backend);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -36,6 +36,8 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 class Application extends App implements IBootstrap {
     public const APP_ID = 'oidc';
 
+	public const DEFAULT_SCOPE = 'openid profile email roles';
+
     private $backend;
 
     public function __construct() {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -39,7 +39,7 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 class Application extends App implements IBootstrap {
     public const APP_ID = 'oidc';
 
-	public const DEFAULT_SCOPE = 'openid profile email roles';
+    public const DEFAULT_SCOPE = 'openid profile email roles';
 
     private $backend;
 
@@ -55,8 +55,8 @@ class Application extends App implements IBootstrap {
         // Register OIDCDiscoveryHandler
         $context->registerWellKnownHandler(OIDCDiscoveryHandler::class);
 
-		$context->registerEventListener(TokenValidationRequestEvent::class, TokenValidationRequestListener::class);
-		$context->registerEventListener(TokenGenerationRequestEvent::class, TokenGenerationRequestListener::class);
+        $context->registerEventListener(TokenValidationRequestEvent::class, TokenValidationRequestListener::class);
+        $context->registerEventListener(TokenGenerationRequestEvent::class, TokenGenerationRequestListener::class);
 
         $this->backend = $this->getContainer()->get(BasicAuthBackend::class);
         OC_User::useBackend($this->backend);

--- a/lib/Controller/LoginRedirectorController.php
+++ b/lib/Controller/LoginRedirectorController.php
@@ -253,7 +253,7 @@ class LoginRedirectorController extends ApiController
         }
 
         // The client must not be expired
-        if ($client->isDcr() && $this->time->getTime() > ($client->getIssuedAt() + $this->appConfig->getAppValue('client_expire_time', '3600'))) {
+        if ($client->isDcr() && $this->time->getTime() > ($client->getIssuedAt() + (int)$this->appConfig->getAppValue('client_expire_time', '3600'))) {
             $this->logger->warning('Client expired. Client id was ' . $client_id . '.');
             $params = [
                 'message' => $this->l->t('Your client is expired. Please inform the administrator of your client.'),

--- a/lib/Controller/LoginRedirectorController.php
+++ b/lib/Controller/LoginRedirectorController.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 namespace OCA\OIDCIdentityProvider\Controller;
 
+use OCA\OIDCIdentityProvider\AppInfo\Application;
 use OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -236,7 +237,7 @@ class LoginRedirectorController extends ApiController
 
         // Set default scope if scope is not set at all
         if (!isset($scope)) {
-            $scope = 'openid profile email roles';
+            $scope = Application::DEFAULT_SCOPE;
         }
 
         $this->clientMapper->cleanUp();

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -217,7 +217,7 @@ class OIDCApiController extends ApiController {
         }
 
         // The accessToken must not be expired
-        if ($this->time->getTime() > $accessToken->getRefreshed() + $expireTime ) {
+        if ($this->time->getTime() > $accessToken->getRefreshed() + $expireTime) {
             $this->accessTokenMapper->delete($accessToken);
             $this->logger->notice('Access token already expired. Client id was ' . $client_id . '.');
             return new JSONResponse([

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -147,7 +147,7 @@ class OIDCApiController extends ApiController {
     #[NoCSRFRequired]
     public function getToken($grant_type, $code, $refresh_token, $client_id, $client_secret): JSONResponse
     {
-        $expireTime = $this->appConfig->getAppValue('expire_time');
+        $expireTime = (int)$this->appConfig->getAppValue('expire_time', '0');
         // We only handle two types
         if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {
             $this->logger->notice('Invalid grant_type provided. Must be authorization_code or refresh_token for client id ' . $client_id . '.');
@@ -208,7 +208,7 @@ class OIDCApiController extends ApiController {
         }
 
         // The client must not be expired
-        if ($client->isDcr() && $this->time->getTime() > ($client->getIssuedAt() + $this->appConfig->getAppValue('client_expire_time', '3600'))) {
+        if ($client->isDcr() && $this->time->getTime() > ($client->getIssuedAt() + (int)$this->appConfig->getAppValue('client_expire_time', '3600'))) {
             $this->logger->warning('Client expired. Client id was ' . $client_id . '.');
             return new JSONResponse([
                 'error' => 'expired_client',
@@ -271,7 +271,7 @@ class OIDCApiController extends ApiController {
             [
                 'access_token' => $newAccessToken,
                 'token_type' => 'Bearer',
-                'expires_in' => intval($expireTime),
+                'expires_in' => $expireTime,
                 'refresh_token' => $newCode,
                 'id_token' => $jwt,
             ]

--- a/lib/Db/AccessToken.php
+++ b/lib/Db/AccessToken.php
@@ -29,7 +29,7 @@ use OCP\AppFramework\Db\Entity;
  * @method int getClientId()
  * @method void setClientId(int $clientId)
  * @method string getUserId()
- * @method void setUserId(int $userId)
+ * @method void setUserId(string $userId)
  * @method string getScope()
  * @method void setScope(string $scope)
  * @method string getHashedCode()

--- a/lib/Event/TokenGenerationRequestEvent.php
+++ b/lib/Event/TokenGenerationRequestEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OIDCIdentityProvider\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted by other apps that need an access token from one of our Oidc clients
+ */
+class TokenGenerationRequestEvent extends Event {
+
+	private ?string $accessToken = null;
+
+	public function __construct(
+		private int $clientId,
+		private string $userId,
+	) {
+		parent::__construct();
+	}
+
+	public function getClientId(): int {
+		return $this->clientId;
+	}
+
+	public function getUserId(): string {
+		return $this->userId;
+	}
+
+	public function getAccessToken(): ?string {
+		return $this->accessToken;
+	}
+
+	public function setAccessToken(string $accessToken): void {
+		$this->accessToken = $accessToken;
+	}
+}

--- a/lib/Event/TokenGenerationRequestEvent.php
+++ b/lib/Event/TokenGenerationRequestEvent.php
@@ -18,14 +18,14 @@ class TokenGenerationRequestEvent extends Event {
 	private ?string $accessToken = null;
 
 	public function __construct(
-		private int $clientId,
+		private string $clientIdentifier,
 		private string $userId,
 	) {
 		parent::__construct();
 	}
 
-	public function getClientId(): int {
-		return $this->clientId;
+	public function getClientIdentifier(): string {
+		return $this->clientIdentifier;
 	}
 
 	public function getUserId(): string {

--- a/lib/Event/TokenValidationRequestEvent.php
+++ b/lib/Event/TokenValidationRequestEvent.php
@@ -11,7 +11,7 @@ namespace OCA\OIDCIdentityProvider\Event;
 use OCP\EventDispatcher\Event;
 
 /**
- * This event is emitted by other apps that need an access token from one of our Oidc clients
+ * This event is emitted by other apps that want to know if an access token is valid
  */
 class TokenValidationRequestEvent extends Event {
 

--- a/lib/Event/TokenValidationRequestEvent.php
+++ b/lib/Event/TokenValidationRequestEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OIDCIdentityProvider\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted by other apps that need an access token from one of our Oidc clients
+ */
+class TokenValidationRequestEvent extends Event {
+
+	private ?bool $isValid = null;
+
+	public function __construct(
+		private string $accessToken,
+	) {
+		parent::__construct();
+	}
+
+	public function getIsValid(): ?bool {
+		return $this->isValid;
+	}
+
+	public function getAccessToken(): string {
+		return $this->accessToken;
+	}
+
+	public function setIsValid(bool $isValid): void {
+		$this->isValid = $isValid;
+	}
+}

--- a/lib/Event/TokenValidationRequestEvent.php
+++ b/lib/Event/TokenValidationRequestEvent.php
@@ -16,6 +16,7 @@ use OCP\EventDispatcher\Event;
 class TokenValidationRequestEvent extends Event {
 
 	private ?bool $isValid = null;
+	private ?string $userId = null;
 
 	public function __construct(
 		private string $accessToken,
@@ -23,15 +24,23 @@ class TokenValidationRequestEvent extends Event {
 		parent::__construct();
 	}
 
-	public function getIsValid(): ?bool {
-		return $this->isValid;
-	}
-
 	public function getAccessToken(): string {
 		return $this->accessToken;
 	}
 
+	public function getIsValid(): ?bool {
+		return $this->isValid;
+	}
+
 	public function setIsValid(bool $isValid): void {
 		$this->isValid = $isValid;
+	}
+
+	public function getUserId(): ?string {
+		return $this->userId;
+	}
+
+	public function setUserId(string $userId): void {
+		$this->userId = $userId;
 	}
 }

--- a/lib/Listener/TokenGenerationRequestListener.php
+++ b/lib/Listener/TokenGenerationRequestListener.php
@@ -16,7 +16,6 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -26,7 +25,6 @@ use Psr\Log\LoggerInterface;
 class TokenGenerationRequestListener implements IEventListener {
 
 	public function __construct(
-		private IUserSession $userSession,
 		private LoggerInterface $logger,
 		private ISecureRandom $random,
 		private ITimeFactory $time,
@@ -40,13 +38,9 @@ class TokenGenerationRequestListener implements IEventListener {
 			return;
 		}
 
-		if (!$this->userSession->isLoggedIn()) {
-			return;
-		}
-
 		$clientId = $event->getClientId();
 		$userId = $event->getUserId();
-		$this->logger->debug('[TokenGenerationRequestListener Listener] received token request for user: ' . $userId . ' and client ID: ' . $clientId);
+		$this->logger->debug('[TokenGenerationRequestListener] received token request event for user: ' . $userId . ' and client ID: ' . $clientId);
 
 		// generate a new access token for the client
 		$expireTime = (int)$this->appConfig->getAppValue('expire_time', '0');

--- a/lib/Listener/TokenGenerationRequestListener.php
+++ b/lib/Listener/TokenGenerationRequestListener.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OIDCIdentityProvider\Listener;
+
+use OCA\OIDCIdentityProvider\AppInfo\Application;
+use OCA\OIDCIdentityProvider\Db\AccessToken;
+use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
+use OCA\OIDCIdentityProvider\Event\TokenGenerationRequestEvent;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
+use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<TokenGenerationRequestEvent|Event>
+ */
+class TokenGenerationRequestListener implements IEventListener {
+
+	public function __construct(
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
+		private ISecureRandom $random,
+		private ITimeFactory $time,
+		private IAppConfig $appConfig,
+		private AccessTokenMapper $accessTokenMapper,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof TokenGenerationRequestEvent) {
+			return;
+		}
+
+		if (!$this->userSession->isLoggedIn()) {
+			return;
+		}
+
+		$clientId = $event->getClientId();
+		$userId = $event->getUserId();
+		$this->logger->debug('[TokenGenerationRequestListener Listener] received token request for user: ' . $userId . ' and client ID: ' . $clientId);
+
+		// generate a new access token for the client
+		$expireTime = (int)$this->appConfig->getAppValue('expire_time', '0');
+		$accessTokenString = $this->random->generate(72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+		$code = $this->random->generate(128, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+		$accessToken = new AccessToken();
+		$accessToken->setClientId($clientId);
+		$accessToken->setUserId($userId);
+		$accessToken->setAccessToken($accessTokenString);
+		$accessToken->setHashedCode(hash('sha512', $code));
+		$accessToken->setScope(substr(Application::DEFAULT_SCOPE, 0, 128));
+		$accessToken->setCreated($this->time->getTime());
+		$accessToken->setRefreshed($this->time->getTime() + $expireTime);
+		$accessToken->setNonce('');
+		$this->accessTokenMapper->insert($accessToken);
+
+		$event->setAccessToken($accessToken->getAccessToken());
+	}
+}

--- a/lib/Listener/TokenValidationRequestListener.php
+++ b/lib/Listener/TokenValidationRequestListener.php
@@ -43,10 +43,13 @@ class TokenValidationRequestListener implements IEventListener {
 		try {
 			$accessToken = $this->accessTokenMapper->getByAccessToken($accessTokenString);
 			$hasExpired = $this->time->getTime() > $accessToken->getRefreshed() + $expireTime;
-			$event->setIsValid(!$hasExpired);
 			// cleanup expired access token
 			if ($hasExpired) {
 				$this->accessTokenMapper->delete($accessToken);
+				$event->setIsValid(false);
+			} else {
+				$event->setIsValid(true);
+				$event->setUserId($accessToken->getUserId());
 			}
 		} catch (AccessTokenNotFoundException $e) {
 			$event->setIsValid(false);

--- a/lib/Listener/TokenValidationRequestListener.php
+++ b/lib/Listener/TokenValidationRequestListener.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OIDCIdentityProvider\Listener;
+
+use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
+use OCA\OIDCIdentityProvider\Event\TokenValidationRequestEvent;
+use OCA\OIDCIdentityProvider\Exceptions\AccessTokenNotFoundException;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<TokenValidationRequestEvent|Event>
+ */
+class TokenValidationRequestListener implements IEventListener {
+
+	public function __construct(
+		private LoggerInterface $logger,
+		private ITimeFactory $time,
+		private IAppConfig $appConfig,
+		private AccessTokenMapper $accessTokenMapper,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof TokenValidationRequestEvent) {
+			return;
+		}
+
+		$accessTokenString = $event->getAccessToken();
+		$this->logger->debug('[TokenValidationRequestListener] received an access token validation request event');
+
+		$expireTime = (int)$this->appConfig->getAppValue('expire_time', '0');
+
+		try {
+			$accessToken = $this->accessTokenMapper->getByAccessToken($accessTokenString);
+			$hasExpired = $this->time->getTime() > $accessToken->getRefreshed() + $expireTime;
+			$event->setIsValid(!$hasExpired);
+			// cleanup expired access token
+			if ($hasExpired) {
+				$this->accessTokenMapper->delete($accessToken);
+			}
+		} catch (AccessTokenNotFoundException $e) {
+			$event->setIsValid(false);
+		}
+	}
+}


### PR DESCRIPTION
Hi there, thank you for this great app!

We are thinking of making it possible to use Nextcloud as an Oidc identity provider in a context where there would be cross-application requests. For example, there would be an OpenProject instance using Nextcloud as an Oidc provider. The goal would be to:

1. Allow the OpenProject users to reach the Nextcloud API using an Oidc access token to authenticate
2. Allow Nextcloud apps to authenticate against the OpenProject API with Oidc access tokens

For 1. the OpenProject users would be in possession of an access token because they logged in using OIDCIdentityProvider.
To accept such access tokens as valid authentication in Nextcloud, we could add a user backend in the OIDCIdentityProvider app that would accept access tokens as bearer tokens (same kind of validation as done by the `/userinfo` endpoint).
But we already have a user backend in the user_oidc app that can validate bearer tokens. I thought it would be more convenient (and make less changes in OIDCIdentityProvider) to emit a `TokenValidationRequestEvent` event in user_oidc's user backend to ask OIDCIdentityProvider if an access token is valid.

For 2. any NC app's backend could emit the `TokenGenerationRequestEvent` to get an access token for a specific client. They could then use this token to authenticate when reaching the OpenProject API.
OpenProject would validate this token by using OIDCIdentityProvider's `/userinfo` endpoint.

What do you think?