### PR TITLE
also return user group array from the /userinfo endpoint

### DIFF
--- a/lib/Controller/UserInfoController.php
+++ b/lib/Controller/UserInfoController.php
@@ -189,18 +189,28 @@ class UserInfoController extends ApiController
 
         ];
 
+        // Check for scopes
+        $scopeArray = preg_split('/ +/', $accessToken->getScope());
+
         $roles = [];
         foreach ($groups as $group) {
             array_push($roles, $group->getGID());
         }
-        $rolesPayload = [
-            'roles' => $roles,
-            'groups' => $roles
-        ];
-        $userInfoPayload = array_merge($userInfoPayload, $rolesPayload);
 
-        // Check for scopes
-        $scopeArray = preg_split('/ +/', $accessToken->getScope());
+        if (in_array("roles", $scopeArray)) {
+            $rolesPayload = [
+                'roles' => $roles
+            ];
+            $userInfoPayload = array_merge($userInfoPayload, $rolesPayload);
+        }
+
+        if (in_array("groups", $scopeArray)) {
+            $groupsPayload = [
+                'groups' => $roles
+            ];
+            $userInfoPayload = array_merge($userInfoPayload, $groupsPayload);
+        }
+
         if (in_array("profile", $scopeArray)) {
             $profile = [
                 'updated_at' => $user->getLastLogin(),

--- a/lib/Controller/UserInfoController.php
+++ b/lib/Controller/UserInfoController.php
@@ -194,7 +194,8 @@ class UserInfoController extends ApiController
             array_push($roles, $group->getGID());
         }
         $rolesPayload = [
-            'roles' => $roles
+            'roles' => $roles,
+            'groups' => $roles
         ];
         $userInfoPayload = array_merge($userInfoPayload, $rolesPayload);
 


### PR DESCRIPTION
At the moment, the `/oidc/token` endpoint (from [this function](https://github.com/H2CK/oidc/blob/bc9e391b527b3234bb3598df4cfe4b6c5c25d761/lib/Controller/OIDCApiController.php#L148)) uses the [JwtGenerator class](https://github.com/H2CK/oidc/blob/bc9e391b527b3234bb3598df4cfe4b6c5c25d761/lib/Util/JwtGenerator.php#L162-L173) to fill its response with claims which were requested as scopes by the user. The `/oidc/userinfo` endpoint doesn't do this, and currently has no way to return the `groups` claim.

This PR is a quick fix to make OIDC clients work which rely on a `groups` claim being available from the `/oidc/userinfo` endpoint.

Edit: I also realized that the endpoint is currently always returning the `roles` claim, even if it wasn't authorized by the user, so this fixes that as well.