### PR TITLE
Support ID token generation and validation via events

### DIFF
--- a/lib/Controller/LoginRedirectorController.php
+++ b/lib/Controller/LoginRedirectorController.php
@@ -372,7 +372,9 @@ class LoginRedirectorController extends ApiController
             $url = $url . '&access_token=' . $accessTokenCode;
         }
         if (in_array('id_token', $responseTypeEntries)) {
-            $jwt = $this->jwtGenerator->generateIdToken($accessToken, $client, $this->request, in_array('token', $responseTypeEntries));
+            $jwt = $this->jwtGenerator->generateIdToken(
+                $accessToken, $client, $this->request->getServerProtocol(), $this->request->getServerHost(), in_array('token', $responseTypeEntries)
+            );
             $url = $url . '&id_token=' . $jwt;
         }
         if (in_array('id_token', $responseTypeEntries) || in_array('token', $responseTypeEntries)) {

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -263,7 +263,7 @@ class OIDCApiController extends ApiController {
 
         $this->accessTokenMapper->update($accessToken);
 
-        $jwt = $this->jwtGenerator->generateIdToken($accessToken, $client, $this->request, false);
+        $jwt = $this->jwtGenerator->generateIdToken($accessToken, $client, $this->request->getServerProtocol(), $this->request->getServerHost(), false);
 
         $this->logger->info('Returned token for user ' . $uid);
 

--- a/lib/Event/TokenGenerationRequestEvent.php
+++ b/lib/Event/TokenGenerationRequestEvent.php
@@ -11,11 +11,14 @@ namespace OCA\OIDCIdentityProvider\Event;
 use OCP\EventDispatcher\Event;
 
 /**
- * This event is emitted by other apps that need an access token from one of our Oidc clients
+ * This event is emitted by other apps that need an access+id token from one of our Oidc clients
  */
 class TokenGenerationRequestEvent extends Event {
 
     private ?string $accessToken = null;
+    private ?string $idToken = null;
+    private ?string $refreshToken = null;
+    private ?int $expiresIn = null;
 
     public function __construct(
         private string $clientIdentifier,
@@ -38,5 +41,29 @@ class TokenGenerationRequestEvent extends Event {
 
     public function setAccessToken(string $accessToken): void {
         $this->accessToken = $accessToken;
+    }
+
+    public function getIdToken(): ?string {
+        return $this->idToken;
+    }
+
+    public function setIdToken(?string $idToken): void {
+        $this->idToken = $idToken;
+    }
+
+    public function getRefreshToken(): ?string {
+        return $this->refreshToken;
+    }
+
+    public function setRefreshToken(?string $refreshToken): void {
+        $this->refreshToken = $refreshToken;
+    }
+
+    public function getExpiresIn(): ?int {
+        return $this->expiresIn;
+    }
+
+    public function setExpiresIn(?int $expiresIn): void {
+        $this->expiresIn = $expiresIn;
     }
 }

--- a/lib/Event/TokenValidationRequestEvent.php
+++ b/lib/Event/TokenValidationRequestEvent.php
@@ -11,7 +11,7 @@ namespace OCA\OIDCIdentityProvider\Event;
 use OCP\EventDispatcher\Event;
 
 /**
- * This event is emitted by other apps that want to know if an access token is valid
+ * This event is emitted by other apps that want to know if an access/id token is valid
  */
 class TokenValidationRequestEvent extends Event {
 
@@ -19,13 +19,13 @@ class TokenValidationRequestEvent extends Event {
     private ?string $userId = null;
 
     public function __construct(
-        private string $accessToken,
+        private string $token,
     ) {
         parent::__construct();
     }
 
-    public function getAccessToken(): string {
-        return $this->accessToken;
+    public function getToken(): string {
+        return $this->token;
     }
 
     public function getIsValid(): ?bool {

--- a/lib/Listener/TokenValidationRequestListener.php
+++ b/lib/Listener/TokenValidationRequestListener.php
@@ -8,14 +8,25 @@ declare(strict_types=1);
 
 namespace OCA\OIDCIdentityProvider\Listener;
 
+use DomainException;
+use Firebase\JWT\BeforeValidException;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Firebase\JWT\SignatureInvalidException;
+use InvalidArgumentException;
 use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
+use OCA\OIDCIdentityProvider\Db\ClientMapper;
 use OCA\OIDCIdentityProvider\Event\TokenValidationRequestEvent;
 use OCA\OIDCIdentityProvider\Exceptions\AccessTokenNotFoundException;
+use OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
 
 /**
  * @implements IEventListener<TokenValidationRequestEvent|Event>
@@ -26,7 +37,9 @@ class TokenValidationRequestListener implements IEventListener {
         private LoggerInterface $logger,
         private ITimeFactory $time,
         private IAppConfig $appConfig,
+        private IUserManager $userManager,
         private AccessTokenMapper $accessTokenMapper,
+        private ClientMapper $clientMapper,
     ) {
     }
 
@@ -35,13 +48,14 @@ class TokenValidationRequestListener implements IEventListener {
             return;
         }
 
-        $accessTokenString = $event->getAccessToken();
-        $this->logger->debug('[TokenValidationRequestListener] received an access token validation request event');
+        $tokenString = $event->getToken();
+        $this->logger->debug('[TokenValidationRequestListener] received a token validation request event');
 
         $expireTime = (int)$this->appConfig->getAppValue('expire_time', '0');
 
+        // check if it's an access token
         try {
-            $accessToken = $this->accessTokenMapper->getByAccessToken($accessTokenString);
+            $accessToken = $this->accessTokenMapper->getByAccessToken($tokenString);
             $hasExpired = $this->time->getTime() > $accessToken->getRefreshed() + $expireTime;
             // cleanup expired access token
             if ($hasExpired) {
@@ -51,8 +65,90 @@ class TokenValidationRequestListener implements IEventListener {
                 $event->setIsValid(true);
                 $event->setUserId($accessToken->getUserId());
             }
+            // stop here if we found this access token
+            return;
         } catch (AccessTokenNotFoundException $e) {
+        }
+
+        // check if it's an id token
+        $oidcKey = [
+            'kty' => 'RSA',
+            'use' => 'sig',
+            'key_ops' => [ 'verify' ],
+            'alg' => 'RS256',
+            'kid' => $this->appConfig->getAppValue('kid'),
+            'n' => $this->appConfig->getAppValue('public_key_n'),
+            'e' => $this->appConfig->getAppValue('public_key_e'),
+        ];
+
+        $jwks = [
+            'keys' => [
+                $oidcKey,
+            ],
+        ];
+
+        try {
+            $decodedStdClass = JWT::decode($tokenString, JWK::parseKeySet($jwks));
+            $decodedJwt = (array) $decodedStdClass;
+        } catch (InvalidArgumentException $e) {
+            // provided key/key-array is empty or malformed.
+            $this->logger->error('Provided key/key-array is empty or malformed.');
+        } catch (DomainException $e) {
+            // provided algorithm is unsupported OR
+            // provided key is invalid OR
+            // unknown error thrown in openSSL or libsodium OR
+            // libsodium is required but not available.
+            $this->logger->error('Provided algorithm is unsupported OR provided key is invalid OR unknown error thrown in openSSL or libsodium OR libsodium is required but not available.');
+        } catch (SignatureInvalidException $e) {
+            // provided JWT signature verification failed.
+            $this->logger->error('Provided JWT signature verification failed.');
+        } catch (BeforeValidException $e) {
+            // provided JWT is trying to be used before "nbf" claim OR
+            // provided JWT is trying to be used before "iat" claim.
+            $this->logger->error('Provided JWT is trying to be used before "nbf" claim OR provided JWT is trying to be used before "iat" claim.');
+        } catch (ExpiredException $e) {
+            // provided JWT is trying to be used after "exp" claim.
+            $this->logger->error('Provided JWT is trying to be used after "exp" claim.');
+        } catch (UnexpectedValueException $e) {
+            // provided JWT is malformed OR
+            // provided JWT is missing an algorithm / using an unsupported algorithm OR
+            // provided JWT algorithm does not match provided key OR
+            // provided key ID in key/key-array is empty or invalid.
+            $this->logger->error('Provided JWT is malformed OR provided JWT is missing an algorithm / using an unsupported algorithm OR provided JWT algorithm does not match provided key OR provided key ID in key/key-array is empty or invalid.');
+        }
+
+        if ($decodedJwt === null) {
+            $this->logger->error('Provided JWT could not be decoded.');
             $event->setIsValid(false);
         }
+
+        // check audience
+        $audience = $decodedJwt['aud'] ?? '';
+        try {
+            $client = $this->clientMapper->getByIdentifier($audience);
+            if ($client === null) {
+                $this->logger->error('Token audience does not match any of our clients identifiers');
+                $event->setIsValid(false);
+                return;
+            }
+        } catch (ClientNotFoundException) {
+            $this->logger->error('Token audience does not match any of our clients identifiers');
+            $event->setIsValid(false);
+            return;
+        }
+
+        // check user ID
+        $userId = $decodedJwt['preferred_username'] ?? '';
+        $user = $this->userManager->get($userId);
+        if ($user === null) {
+            $this->logger->error('Provided user in JWT is unknown.');
+            $event->setIsValid(false);
+            return;
+        }
+
+        // all good
+        $event->setIsValid(true);
+        $event->setUserId($userId);
+
     }
 }

--- a/lib/Util/JwtGenerator.php
+++ b/lib/Util/JwtGenerator.php
@@ -31,6 +31,7 @@ use OCA\OIDCIdentityProvider\Db\Group;
 use OCA\OIDCIdentityProvider\Db\AccessToken;
 use OCA\OIDCIdentityProvider\Db\Client;
 use OCA\DAV\CardDAV\Converter;
+use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -97,17 +98,20 @@ class JwtGenerator
         $this->converter = Server::get(Converter::class);
     }
 
-    /**
-     * Generate JWT Token
-     *
-     * @param AccessToken $accessToken
-     * @param Client $client
-     * @return string
-     */
-    public function generateIdToken(AccessToken $accessToken, Client $client, IRequest $request, bool $atHash): string
-    {
-        $expireTime = $this->appConfig->getAppValue('expire_time');
-        $issuer = $request->getServerProtocol() . '://' . $request->getServerHost() . $this->urlGenerator->getWebroot();
+	/**
+	 * Generate JWT Token
+	 *
+	 * @param AccessToken $accessToken
+	 * @param Client $client
+	 * @param string $issuerProtocol
+	 * @param string $issuerHost
+	 * @param bool $atHash
+	 * @return string
+	 * @throws PropertyDoesNotExistException
+	 */
+    public function generateIdToken(AccessToken $accessToken, Client $client, string $issuerProtocol, string $issuerHost, bool $atHash): string {
+        $expireTime = (int)$this->appConfig->getAppValue('expire_time');
+        $issuer = $issuerProtocol . '://' . $issuerHost . $this->urlGenerator->getWebroot();
         $nonce = $accessToken->getNonce();
         $uid = $accessToken->getUserId();
         $user = $this->userManager->get($uid);


### PR DESCRIPTION
This is a followup to #515 adding support for ID token validation and generation via the same events.

* When handling TokenGenerationRequestEvent, an ID token is also generated
* When handling TokenValidationRequestEvent, the listener tries to validate it as an ID token as well

To decode an ID token, I took inspiration from the LogoutController.

For the ID token generation, I made a very small change in `JwtGenerator::generateIdToken` to not depend on an IRequest object so this method could also be used by `TokenGenerationRequestListener`.