### PR TITLE
Amend Makefile for alternative composer setups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ ifeq (, $(composer))
 	php $(build_tools_directory)/composer.phar install --prefer-dist
 	php $(build_tools_directory)/composer.phar update --prefer-dist
 else
-	php $(build_tools_directory)/composer.phar install --prefer-dist
-	php $(build_tools_directory)/composer.phar update --prefer-dist
+	$(composer) install --prefer-dist
+	$(composer) update --prefer-dist
 endif
 
 # Install translationtool from https://github.com/nextcloud/docker-ci/tree/master/translations/translationtool


### PR DESCRIPTION
### Proposal

- amend Makefile to use alternative composer setups for building the app

### Use Case and Setup description

I have the use case of running a docker based development setup with a standard nextcloud image, `nextcloud:30`, and a number of apps on specific branches - the `oidc` app being one of those.

So, I cloned the `oidc` repo locally, needed to build it to mount the build result into the running nextcloud container. As usual, with a docker dev setup, I do not have any build tool dependencies on my local machine, hence I checked, what are the dependencies to build `oidc`. I used this small Dockerfile to build it:

```Dockerfile
FROM composer:2
LABEL authors="openproject"

COPY --from=node:22-alpine /usr/local/bin /usr/local/bin
COPY --from=node:22-alpine /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm

RUN npm install -g webpack@5.98.0
RUN npm install -g webpack-cli@6.0.1

RUN apk add rsync
```

As you can see, I use the composer base image, which comes with `php`, `make` and `composer` binaries. I need to run the following commands to build `oidc` for the enabling in Nextcloud:

```shell
make composer
make build
```

Running `make composer` I noticed, that the `Makefile` does not support running `install` and `update`, if the `composer` is installed in a different way. My small change fixes this path in the `if-else`.

Feel free to take it, drop it or comment on it. ;) 

Happy to hear from you.