### PR TITLE
feat: accept extra scopes param

### DIFF
--- a/lib/Event/TokenGenerationRequestEvent.php
+++ b/lib/Event/TokenGenerationRequestEvent.php
@@ -24,6 +24,7 @@ class TokenGenerationRequestEvent extends Event {
     public function __construct(
         private string $clientIdentifier,
         private string $userId,
+        private string $extraScopes = "",
     ) {
         parent::__construct();
     }
@@ -34,6 +35,10 @@ class TokenGenerationRequestEvent extends Event {
 
     public function getUserId(): string {
         return $this->userId;
+    }
+
+    public function getExtraScopes(): string {
+        return $this->extraScopes;
     }
 
     public function getAccessToken(): ?string {

--- a/lib/Listener/TokenGenerationRequestListener.php
+++ b/lib/Listener/TokenGenerationRequestListener.php
@@ -47,6 +47,13 @@ class TokenGenerationRequestListener implements IEventListener {
 
         $clientIdentifier = $event->getClientIdentifier();
         $userId = $event->getUserId();
+
+        $extraScopes = $event->getExtraScopes();
+        $scopes = Application::DEFAULT_SCOPE;
+        if ($extraScopes !== "") {
+            $scopes .= " " . $extraScopes;
+        }
+
         $this->logger->debug('[TokenGenerationRequestListener] received token request event for user: ' . $userId . ' and client identifier: ' . $clientIdentifier);
 
         // get client from identifier
@@ -73,7 +80,7 @@ class TokenGenerationRequestListener implements IEventListener {
         $accessToken->setClientId($client->getId());
         $accessToken->setUserId($userId);
         $accessToken->setHashedCode(hash('sha512', $code));
-        $accessToken->setScope(substr(Application::DEFAULT_SCOPE, 0, 128));
+        $accessToken->setScope(substr($scopes, 0, 128));
         $accessToken->setCreated($this->time->getTime());
         $accessToken->setRefreshed($this->time->getTime() + $expireTime);
         $accessToken->setNonce('');


### PR DESCRIPTION
Make `TokenGenerationRequestEvent` to accept extra scopes. With this we can request optional scopes in the token while using `TokenGenerationRequestEvent`.

#### Usage:
```php
$event = new \OCA\OIDCIdentityProvider\Event\TokenGenerationRequestEvent($targetAudience, $userId, $extraScopes);
$event->getAccessToken()
```

Follow up of https://github.com/H2CK/oidc/issues/537
Need for https://github.com/nextcloud/user_oidc/issues/1091 implementation