### PR TITLE
chore(i18n): Adapt string to fit guidelines

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -204,7 +204,7 @@
 					{{ t('oidc', 'Select if user is able to modify user specific settings') }}
 				</option>
 				<option value="no">
-					{{ t('oidc', 'User can not edit any settings') }}
+					{{ t('oidc', 'User cannot edit any settings') }}
 				</option>
 				<option value="enabled">
 					{{ t('oidc', 'User can edit settings') }}


### PR DESCRIPTION
Reported at Transifex.

See https://docs.nextcloud.com/server/latest/developer_manual/basics/translations.html#dos-and-don-ts

I have seen code is not active but the string is available at Transifex.