### PR TITLE
fix(validation): allow RFC 6749 VSCHAR characters in client_id and client_secret

### DIFF
--- a/lib/BasicAuthBackend.php
+++ b/lib/BasicAuthBackend.php
@@ -84,7 +84,7 @@ class BasicAuthBackend extends \OC\User\Backend {
      * Check if the password is correct without logging in the user
      */
     public function checkPassword($uid, $password) {
-        if (strlen($uid) !== 64 || strlen($password) !== 64) {
+        if (strlen($uid) < 32 || strlen($uid) > 64 || strlen($password) < 32 || strlen($password) > 64) {
             return false;
         }
 
@@ -187,7 +187,7 @@ class BasicAuthBackend extends \OC\User\Backend {
      * @return boolean
      */
     public function userExists($uid) {
-        if (strlen($uid) !== 64) {
+        if (strlen($uid) < 32 || strlen($uid) > 64) {
             return false;
         }
 

--- a/lib/Command/Clients/OIDCCreate.php
+++ b/lib/Command/Clients/OIDCCreate.php
@@ -105,14 +105,14 @@ class OIDCCreate extends Command
                 'client_id',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'The client id to be used. If not provided the client id will be generated internally. Requirements: chars A-Za-z0-9 & min length 32 & max length 64',
+                'The client id to be used. If not provided the client id will be generated internally. Requirements: printable ASCII except : and length 32-64',
                 ''
             )
             ->addOption(
                 'client_secret',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'The client secret to be used. If not provided the client secret will be generated internally. Requirements: chars A-Za-z0-9 & min length 32 & max length 64',
+                'The client secret to be used. If not provided the client secret will be generated internally. Requirements: printable ASCII except : and length 32-64',
                 ''
             )
             ->addOption(
@@ -157,15 +157,15 @@ class OIDCCreate extends Command
             $clientId = $input->getOption('client_id');
             $clientSecret = $input->getOption('client_secret');
             if (isset($clientId) && trim($clientId) !== '') {
-                if (filter_var($clientId, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[A-Za-z0-9]{32,64}$/"))) === false) {
-                    throw new CliException("Your clientId must comply with the following rules: chars A-Za-z0-9 & min length 32 & max length 64");
+                if (filter_var($clientId, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[\x21-\x39\x3B-\x7E]{32,64}$/"))) === false) {
+                    throw new CliException("Your clientId must comply with the following rules: printable ASCII except : and length 32-64");
                 }
                 $client->setClientIdentifier($clientId);
             }
 
             if (isset($clientSecret) && trim($clientSecret) !== '') {
-                if (filter_var($clientSecret, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[A-Za-z0-9]{32,64}$/"))) === false) {
-                    throw new CliException("Your clientSecret must comply with the following rules: chars A-Za-z0-9 & min length 32 & max length 64");
+                if (filter_var($clientSecret, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[\x21-\x39\x3B-\x7E]{32,64}$/"))) === false) {
+                    throw new CliException("Your clientSecret must comply with the following rules: printable ASCII except : and length 32-64");
                 }
                 $client->setSecret($clientSecret);
             }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -134,15 +134,15 @@ class SettingsController extends Controller
         );
 
         if (isset($clientId) && trim($clientId) !== '') {
-            if (filter_var($clientId, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[A-Za-z0-9]{32,64}$/"))) === false) {
-                return new JSONResponse(['message' => $this->l->t('Your client ID must comply with the following rules: chars A-Za-z0-9 & min length 32 & max length 64')], Http::STATUS_BAD_REQUEST);
+            if (filter_var($clientId, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[\x21-\x39\x3B-\x7E]{32,64}$/"))) === false) {
+                return new JSONResponse(['message' => $this->l->t('Your client ID must comply with the following rules: printable ASCII except : and length 32-64')], Http::STATUS_BAD_REQUEST);
             }
             $client->setClientIdentifier($clientId);
         }
 
         if (isset($clientSecret) && trim($clientSecret) !== '') {
-            if (filter_var($clientSecret, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[A-Za-z0-9]{32,64}$/"))) === false) {
-                return new JSONResponse(['message' => $this->l->t('Your client secret must comply with the following rules: chars A-Za-z0-9 & min length 32 & max length 64')], Http::STATUS_BAD_REQUEST);
+            if (filter_var($clientSecret, FILTER_VALIDATE_REGEXP, array("options" => array("regexp" => "/^[\x21-\x39\x3B-\x7E]{32,64}$/"))) === false) {
+                return new JSONResponse(['message' => $this->l->t('Your client secret must comply with the following rules: printable ASCII except : and length 32-64')], Http::STATUS_BAD_REQUEST);
             }
             $client->setSecret($clientSecret);
         }

--- a/tests/Unit/BasicAuthBackendTest.php
+++ b/tests/Unit/BasicAuthBackendTest.php
@@ -110,12 +110,10 @@ class BasicAuthBackendTest extends TestCase {
         $this->request->method('getRequestUri')
             ->willReturn('/apps/oidc/token');
 
-        $client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $client->method('getClientIdentifier')->willReturn($uid);
-        $client->method('getSecret')->willReturn($secret);
-        $client->method('getType')->willReturn('confidential');
+        $client = new Client();
+        $client->setClientIdentifier($uid);
+        $client->setSecret($secret);
+        $client->setType('confidential');
 
         $this->clientMapper->method('getByIdentifier')
             ->with($uid)
@@ -150,12 +148,10 @@ class BasicAuthBackendTest extends TestCase {
         $this->request->method('getRequestUri')
             ->willReturn('/apps/oidc/introspect');
 
-        $client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $client->method('getClientIdentifier')->willReturn($this->uid64);
-        $client->method('getSecret')->willReturn($this->secret64);
-        $client->method('getType')->willReturn('confidential');
+        $client = new Client();
+        $client->setClientIdentifier($this->uid64);
+        $client->setSecret($this->secret64);
+        $client->setType('confidential');
 
         $this->clientMapper->method('getByIdentifier')
             ->with($this->uid64)
@@ -170,12 +166,10 @@ class BasicAuthBackendTest extends TestCase {
         $this->request->method('getRequestUri')
             ->willReturn('/apps/oidc/token');
 
-        $client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $client->method('getClientIdentifier')->willReturn($this->uid64);
-        $client->method('getSecret')->willReturn('WrongSecretThatIsExactlySixtyFourCharactersLongForTestingPurpose1');
-        $client->method('getType')->willReturn('confidential');
+        $client = new Client();
+        $client->setClientIdentifier($this->uid64);
+        $client->setSecret('WrongSecretThatIsExactlySixtyFourCharactersLongForTestingPurpose1');
+        $client->setType('confidential');
 
         $this->clientMapper->method('getByIdentifier')
             ->with($this->uid64)
@@ -207,10 +201,8 @@ class BasicAuthBackendTest extends TestCase {
     }
 
     public function testUserExistsAccepts64Char() {
-        $client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $client->method('getClientIdentifier')->willReturn($this->uid64);
+        $client = new Client();
+        $client->setClientIdentifier($this->uid64);
 
         $this->clientMapper->method('getByIdentifier')
             ->with($this->uid64)
@@ -220,10 +212,8 @@ class BasicAuthBackendTest extends TestCase {
     }
 
     public function testUserExistsAccepts48Char() {
-        $client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $client->method('getClientIdentifier')->willReturn($this->uid48);
+        $client = new Client();
+        $client->setClientIdentifier($this->uid48);
 
         $this->clientMapper->method('getByIdentifier')
             ->with($this->uid48)
@@ -233,10 +223,8 @@ class BasicAuthBackendTest extends TestCase {
     }
 
     public function testUserExistsAccepts32Char() {
-        $client = $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $client->method('getClientIdentifier')->willReturn($this->uid32);
+        $client = new Client();
+        $client->setClientIdentifier($this->uid32);
 
         $this->clientMapper->method('getByIdentifier')
             ->with($this->uid32)

--- a/tests/Unit/BasicAuthBackendTest.php
+++ b/tests/Unit/BasicAuthBackendTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace OCA\OIDCIdentityProvider\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IDBConnection;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Security\ISecureRandom;
+
+use OCA\OIDCIdentityProvider\BasicAuthBackend;
+use OCA\OIDCIdentityProvider\Db\Client;
+use OCA\OIDCIdentityProvider\Db\ClientMapper;
+use OCA\OIDCIdentityProvider\Db\CustomClaimMapper;
+use OCA\OIDCIdentityProvider\Db\RedirectUriMapper;
+use OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException;
+
+use Psr\Log\LoggerInterface;
+
+class BasicAuthBackendTest extends TestCase {
+    /** @var BasicAuthBackend */
+    private $backend;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|IRequest */
+    private $request;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|IURLGenerator */
+    private $urlGenerator;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|ClientMapper */
+    private $clientMapper;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|LoggerInterface */
+    private $logger;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|IAppConfig */
+    private $appConfig;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|ITimeFactory */
+    private $time;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|IDBConnection */
+    private $db;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|ISecureRandom */
+    private $secureRandom;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|RedirectUriMapper */
+    private $redirectUriMapper;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|CustomClaimMapper */
+    private $customClaimMapper;
+
+    /** 64-char test credentials (auto-generated length) */
+    private $uid64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345678901';
+    private $secret64 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01';
+
+    /** 48-char test credentials (user-provided length) */
+    private $uid48 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv';
+    private $secret48 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKL';
+
+    /** 32-char test credentials (minimum valid length) */
+    private $uid32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef';
+    private $secret32 = '0123456789abcdefghijklmnopqrstuv';
+
+    public function setUp(): void {
+        $this->request = $this->getMockBuilder(IRequest::class)->getMock();
+        $this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $this->appConfig = $this->getMockBuilder(IAppConfig::class)->getMock();
+        $this->secureRandom = $this->getMockBuilder(ISecureRandom::class)->getMock();
+        $this->time = $this->getMockBuilder(ITimeFactory::class)->getMock();
+        $this->db = $this->getMockBuilder(IDBConnection::class)->getMock();
+        $this->redirectUriMapper = $this->getMockBuilder(RedirectUriMapper::class)->setConstructorArgs([
+            $this->db,
+            $this->time,
+            $this->appConfig])->getMock();
+        $this->customClaimMapper = $this->getMockBuilder(CustomClaimMapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->clientMapper = $this->getMockBuilder(ClientMapper::class)->setConstructorArgs([
+            $this->db,
+            $this->time,
+            $this->appConfig,
+            $this->redirectUriMapper,
+            $this->customClaimMapper,
+            $this->secureRandom,
+            $this->logger])->getMock();
+
+        $this->backend = new BasicAuthBackend(
+            $this->request,
+            $this->urlGenerator,
+            $this->clientMapper,
+            $this->logger
+        );
+    }
+
+    // --- checkPassword: length validation ---
+
+    public function testCheckPasswordRejectsTooShort() {
+        $this->assertFalse($this->backend->checkPassword('short', 'short'));
+    }
+
+    public function testCheckPasswordRejectsTooLong() {
+        $uid = str_repeat('a', 65);
+        $secret = str_repeat('b', 65);
+        $this->assertFalse($this->backend->checkPassword($uid, $secret));
+    }
+
+    public function testCheckPasswordRejectsEmpty() {
+        $this->assertFalse($this->backend->checkPassword('', ''));
+    }
+
+    // --- checkPassword: accepts valid lengths on token endpoint ---
+
+    private function setupValidClient(string $uid, string $secret): void {
+        $this->request->method('getRequestUri')
+            ->willReturn('/apps/oidc/token');
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->method('getClientIdentifier')->willReturn($uid);
+        $client->method('getSecret')->willReturn($secret);
+        $client->method('getType')->willReturn('confidential');
+
+        $this->clientMapper->method('getByIdentifier')
+            ->with($uid)
+            ->willReturn($client);
+    }
+
+    public function testCheckPasswordAccepts64CharCredentials() {
+        $this->setupValidClient($this->uid64, $this->secret64);
+        $this->assertTrue($this->backend->checkPassword($this->uid64, $this->secret64));
+    }
+
+    public function testCheckPasswordAccepts48CharCredentials() {
+        $this->setupValidClient($this->uid48, $this->secret48);
+        $this->assertTrue($this->backend->checkPassword($this->uid48, $this->secret48));
+    }
+
+    public function testCheckPasswordAccepts32CharCredentials() {
+        $this->setupValidClient($this->uid32, $this->secret32);
+        $this->assertTrue($this->backend->checkPassword($this->uid32, $this->secret32));
+    }
+
+    // --- checkPassword: endpoint restriction ---
+
+    public function testCheckPasswordRejectsNonTokenEndpoint() {
+        $this->request->method('getRequestUri')
+            ->willReturn('/apps/files/index.php');
+
+        $this->assertFalse($this->backend->checkPassword($this->uid64, $this->secret64));
+    }
+
+    public function testCheckPasswordAcceptsIntrospectEndpoint() {
+        $this->request->method('getRequestUri')
+            ->willReturn('/apps/oidc/introspect');
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->method('getClientIdentifier')->willReturn($this->uid64);
+        $client->method('getSecret')->willReturn($this->secret64);
+        $client->method('getType')->willReturn('confidential');
+
+        $this->clientMapper->method('getByIdentifier')
+            ->with($this->uid64)
+            ->willReturn($client);
+
+        $this->assertTrue($this->backend->checkPassword($this->uid64, $this->secret64));
+    }
+
+    // --- checkPassword: wrong secret ---
+
+    public function testCheckPasswordRejectsWrongSecret() {
+        $this->request->method('getRequestUri')
+            ->willReturn('/apps/oidc/token');
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->method('getClientIdentifier')->willReturn($this->uid64);
+        $client->method('getSecret')->willReturn('WrongSecretThatIsExactlySixtyFourCharactersLongForTestingPurpose1');
+        $client->method('getType')->willReturn('confidential');
+
+        $this->clientMapper->method('getByIdentifier')
+            ->with($this->uid64)
+            ->willReturn($client);
+
+        $this->assertFalse($this->backend->checkPassword($this->uid64, $this->secret64));
+    }
+
+    // --- checkPassword: unknown client ---
+
+    public function testCheckPasswordRejectsUnknownClient() {
+        $this->request->method('getRequestUri')
+            ->willReturn('/apps/oidc/token');
+
+        $this->clientMapper->method('getByIdentifier')
+            ->willThrowException(new ClientNotFoundException());
+
+        $this->assertFalse($this->backend->checkPassword($this->uid64, $this->secret64));
+    }
+
+    // --- userExists: length validation ---
+
+    public function testUserExistsRejectsTooShort() {
+        $this->assertFalse($this->backend->userExists('short'));
+    }
+
+    public function testUserExistsRejectsTooLong() {
+        $this->assertFalse($this->backend->userExists(str_repeat('a', 65)));
+    }
+
+    public function testUserExistsAccepts64Char() {
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->method('getClientIdentifier')->willReturn($this->uid64);
+
+        $this->clientMapper->method('getByIdentifier')
+            ->with($this->uid64)
+            ->willReturn($client);
+
+        $this->assertTrue($this->backend->userExists($this->uid64));
+    }
+
+    public function testUserExistsAccepts48Char() {
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->method('getClientIdentifier')->willReturn($this->uid48);
+
+        $this->clientMapper->method('getByIdentifier')
+            ->with($this->uid48)
+            ->willReturn($client);
+
+        $this->assertTrue($this->backend->userExists($this->uid48));
+    }
+
+    public function testUserExistsAccepts32Char() {
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->method('getClientIdentifier')->willReturn($this->uid32);
+
+        $this->clientMapper->method('getByIdentifier')
+            ->with($this->uid32)
+            ->willReturn($client);
+
+        $this->assertTrue($this->backend->userExists($this->uid32));
+    }
+
+    public function testUserExistsReturnsFalseForUnknownClient() {
+        $this->clientMapper->method('getByIdentifier')
+            ->willThrowException(new ClientNotFoundException());
+
+        $this->assertFalse($this->backend->userExists($this->uid64));
+    }
+}

--- a/tests/Unit/Command/Clients/OIDCCreateTest.php
+++ b/tests/Unit/Command/Clients/OIDCCreateTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OIDCIdentityProvider\Tests\Unit\Command\Clients;
+
+use OCA\OIDCIdentityProvider\AppInfo\Application;
+use OCA\OIDCIdentityProvider\Command\Clients\OIDCCreate;
+use OCA\OIDCIdentityProvider\Db\Client;
+use OCA\OIDCIdentityProvider\Db\ClientMapper;
+use OCA\OIDCIdentityProvider\Service\RedirectUriService;
+use OCP\AppFramework\Services\IAppConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class OIDCCreateTest extends TestCase
+{
+    private IAppConfig $appConfig;
+    private ClientMapper $clientMapper;
+    private RedirectUriService $redirectUriService;
+    private OIDCCreate $command;
+
+    protected function setUp(): void
+    {
+        $this->appConfig = $this->createMock(IAppConfig::class);
+        $this->clientMapper = $this->createMock(ClientMapper::class);
+        $this->redirectUriService = $this->createMock(RedirectUriService::class);
+
+        $this->appConfig
+            ->method('getAppValueString')
+            ->willReturnMap([
+                [Application::APP_CONFIG_DEFAULT_TOKEN_TYPE, Application::DEFAULT_TOKEN_TYPE, Application::DEFAULT_TOKEN_TYPE],
+                [Application::APP_CONFIG_ALLOW_SUBDOMAIN_WILDCARDS, Application::DEFAULT_ALLOW_SUBDOMAIN_WILDCARDS, Application::DEFAULT_ALLOW_SUBDOMAIN_WILDCARDS],
+            ]);
+
+        $this->redirectUriService
+            ->method('isValidRedirectUri')
+            ->willReturn(true);
+
+        $this->clientMapper
+            ->method('insert')
+            ->willReturnCallback(static fn (Client $client) => $client);
+
+        $this->command = new OIDCCreate(
+            $this->appConfig,
+            $this->clientMapper,
+            $this->redirectUriService
+        );
+    }
+
+    #[DataProvider('validCredentialProvider')]
+    public function testExecuteAcceptsValidCredentials(string $clientId, string $clientSecret): void
+    {
+        $tester = new CommandTester($this->command);
+
+        $statusCode = $tester->execute([
+            'name' => 'Test Client',
+            'redirect_uris' => ['https://local.lo/callback'],
+            '--client_id' => $clientId,
+            '--client_secret' => $clientSecret,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $statusCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString($clientId, $display);
+        $this->assertStringContainsString($clientSecret, $display);
+    }
+
+    public function testExecuteRejectsColonInClientId(): void
+    {
+        $tester = new CommandTester($this->command);
+
+        $statusCode = $tester->execute([
+            'name' => 'Test Client',
+            'redirect_uris' => ['https://local.lo/callback'],
+            '--client_id' => 'client:id-with-colon-01234567890123',
+            '--client_secret' => '0582bb51ac974f318c4fe11779c439a0',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $statusCode);
+        $this->assertStringContainsString(
+            'Your clientId must comply with the following rules: printable ASCII except : and length 32-64',
+            $tester->getDisplay()
+        );
+    }
+
+    public static function validCredentialProvider(): array
+    {
+        return [
+            'alphanumeric credentials' => [
+                '0582bb51ac974f318c4fe11779c439a0',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+            'hyphen in client id' => [
+                'client-id-with-hyphen-012345678901',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+            'underscore in client id' => [
+                'client_id_with_underscores_0123456',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+            'dot in client id' => [
+                'client.id.with.dots.01234567890123',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -224,6 +224,74 @@ class SettingsControllerTest extends TestCase {
         $this->assertEquals($clientSecret, $result->getData()['clientSecret']);
     }
 
+    #[DataProvider('validCredentialProvider')]
+    public function testAddClientAcceptsValidCredentials(string $clientId, string $clientSecret): void {
+        $name = 'TEST';
+        $redirectUri = 'https://local.lo';
+        $signingAlg = 'RS256';
+        $type = 'confidential';
+        $flowType = 'code';
+        $tokenType = 'opaque';
+
+        $this->clientMapper
+            ->method('insert')
+            ->willReturnCallback(
+                function ($arg) {
+                    $client = $arg;
+                    $client->setId(1);
+                    return $client;
+                }
+            );
+
+        $this->redirectUriMapper
+            ->method('getByClientId')
+            ->willReturnCallback(
+                function ($arg) {
+                    $redirectUri = new RedirectUri();
+                    $redirectUri->setId(1);
+                    $redirectUri->setClientId(1);
+                    $redirectUri->setRedirectUri('https://local.lo');
+                    return [$redirectUri];
+                }
+            );
+
+        $result = $this->controller->addClient(
+            $name,
+            $redirectUri,
+            $signingAlg,
+            $type,
+            $flowType,
+            $tokenType,
+            $clientId,
+            $clientSecret
+        );
+
+        $this->assertEquals(Http::STATUS_OK, $result->getStatus(), 'Status Code does not match!');
+        $this->assertEquals($clientId, $result->getData()['clientId']);
+        $this->assertEquals($clientSecret, $result->getData()['clientSecret']);
+    }
+
+    public static function validCredentialProvider(): array {
+        return [
+            'alphanumeric credentials' => [
+                '0582bb51ac974f318c4fe11779c439a0',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+            'hyphen in client id' => [
+                'client-id-with-hyphen-012345678901',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+            'underscore in client id' => [
+                'client_id_with_underscores_0123456',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+            'dot in client id' => [
+                'client.id.with.dots.01234567890123',
+                '0582bb51ac974f318c4fe11779c439a0',
+            ],
+        ];
+    }
+
     public function testAddClientwWrongCreds1() {
         $name = 'TEST';
         $redirectUri = 'https://local.lo';
@@ -363,6 +431,34 @@ class SettingsControllerTest extends TestCase {
         );
 
         $this->assertEquals(Http::STATUS_BAD_REQUEST, $result->getStatus(), 'Status Code does not match!');
+    }
+
+    public function testAddClientRejectsColonInClientId(): void {
+        $name = 'TEST';
+        $redirectUri = 'https://local.lo';
+        $signingAlg = 'RS256';
+        $type = 'confidential';
+        $flowType = 'code';
+        $tokenType = 'opaque';
+        $clientId = 'client:id-with-colon-01234567890123';
+        $clientSecret = '0582bb51ac974f318c4fe11779c439a0';
+
+        $result = $this->controller->addClient(
+            $name,
+            $redirectUri,
+            $signingAlg,
+            $type,
+            $flowType,
+            $tokenType,
+            $clientId,
+            $clientSecret
+        );
+
+        $this->assertEquals(Http::STATUS_BAD_REQUEST, $result->getStatus(), 'Status Code does not match!');
+        $this->assertEquals(
+            'Your client ID must comply with the following rules: printable ASCII except : and length 32-64',
+            $result->getData()['message']
+        );
     }
 
     public function testAddClientBadRedirectUri() {

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -105,6 +105,7 @@ class SettingsControllerTest extends TestCase {
             $this->db,
             $this->groupManager])->getMock();
         $this->l = $this->getMockBuilder(IL10N::class)->getMock();
+        $this->l->method('t')->willReturnCallback(static fn (string $text): string => $text);
         $this->redirectUriService = new RedirectUriService(
             $this->logger
         );


### PR DESCRIPTION
## Summary

I'm trying to automate OIDC clients provisioning in Nextcloud and hit a wall, took me some time to understand issue. I was generating client id and secrets with the terminal, but realized that the implementation of the oidc plugin is too restrictive. Here is my proposal.

The current validation in `oidc:create` and `SettingsController.addClient()` restricts `client_id` and `client_secret` to `[A-Za-z0-9]` characters only.

RFC 6749 (OAuth 2.0) Appendix A https://datatracker.ietf.org/doc/html/rfc6749#appendix-A defines both as `*VSCHAR` (any printable ASCII, `%x20-7E`). The only character that must be excluded is `:` (colon), which is the Basic auth username/password separator per RFC 7617.

The current restriction breaks interoperability with any credential generator that follows standard naming conventions (e.g. `myapp-service`, UUIDs, hyphenated identifiers). The failure mode is particularly opaque: the CLI rejects the credential at creation time with a non-obvious error message, and if a credential somehow reaches the token endpoint with a non-alphanumeric character, Nextcloud logs a generic `Login failed` with no indication of the root cause.

## Changes

- Relax the validation regex in `lib/Command/Clients/OIDCCreate.php` and `lib/Controller/SettingsController.php` from `/^[A-Za-z0-9]{32,64}$/` to VSCHAR minus `:` and space: `/^[\x21-\x39\x3B-\x7E]{32,64}$/`
- Update error messages accordingly
- Add unit tests for credentials containing `-`, `_`, `.` (should pass) and `:` (should fail)

## Impact

No existing credentials are affected - the alphanumeric subset is fully contained within the new character set. The 32-64 length requirement is preserved as a security floor.
