### PR TITLE
fix(introspection): compute token expiry from refreshed, not created

### DIFF
--- a/lib/Controller/IntrospectionController.php
+++ b/lib/Controller/IntrospectionController.php
@@ -160,15 +160,26 @@ class IntrospectionController extends ApiController
             return new JSONResponse(['active' => false]);
         }
 
-        // Check if token is expired
+        // Check if token is expired.
+        //
+        // Expiry is computed from `refreshed`, NOT `created`. The refresh_token
+        // grant (OIDCApiController::getToken) mints a fresh access token on the
+        // existing row and advances `refreshed`, but leaves `created` at the
+        // original issuance time. Using `created` here would report every
+        // refreshed token inactive once the *original* token's lifetime elapsed,
+        // even though the token is still valid — breaking token renewal for
+        // resource servers that introspect. This matches the expiry basis used
+        // by UserInfoController, TokenValidationRequestListener and
+        // OIDCApiController.
         $expireTime = (int)$this->appConfig->getAppValueString('expire_time', Application::DEFAULT_EXPIRE_TIME);
-        $tokenExpiryTime = $accessToken->getCreated() + $expireTime;
+        $tokenExpiryTime = $accessToken->getRefreshed() + $expireTime;
         $currentTime = $this->time->getTime();
 
         if ($currentTime > $tokenExpiryTime) {
             $this->logger->info('Token expired during introspection', [
                 'client_id' => $client->getClientIdentifier(),
                 'token_created' => $accessToken->getCreated(),
+                'token_refreshed' => $accessToken->getRefreshed(),
                 'token_expired_at' => $tokenExpiryTime,
                 'current_time' => $currentTime
             ]);

--- a/tests/Unit/Controller/IntrospectionControllerTest.php
+++ b/tests/Unit/Controller/IntrospectionControllerTest.php
@@ -138,9 +138,10 @@ class IntrospectionControllerTest extends TestCase {
             ->method('getByIdentifier')
             ->willReturn($client);
 
-        // Create an expired token
+        // Create an expired token (never refreshed: created == refreshed)
         $accessToken = new AccessToken();
         $accessToken->setCreated(1000000); // Old timestamp
+        $accessToken->setRefreshed(1000000);
         $accessToken->setUserId('user1');
         $accessToken->setClientId(1);
 
@@ -179,6 +180,7 @@ class IntrospectionControllerTest extends TestCase {
         // Create a valid token
         $accessToken = new AccessToken();
         $accessToken->setCreated(1000000);
+        $accessToken->setRefreshed(1000000);
         $accessToken->setUserId('user1');
         $accessToken->setClientId(1);
         $accessToken->setScope('openid profile email');
@@ -241,6 +243,7 @@ class IntrospectionControllerTest extends TestCase {
         // Create a valid token with resource matching the requesting client
         $accessToken = new AccessToken();
         $accessToken->setCreated(1000000);
+        $accessToken->setRefreshed(1000000);
         $accessToken->setUserId('user1');
         $accessToken->setClientId(1);
         $accessToken->setScope('openid profile email');
@@ -298,6 +301,7 @@ class IntrospectionControllerTest extends TestCase {
         // Create a valid token with different resource and client
         $accessToken = new AccessToken();
         $accessToken->setCreated(1000000);
+        $accessToken->setRefreshed(1000000);
         $accessToken->setUserId('user1');
         $accessToken->setClientId(1);
         $accessToken->setScope('openid profile email');
@@ -336,6 +340,72 @@ class IntrospectionControllerTest extends TestCase {
         // Should return inactive to not reveal token exists
         $this->assertEquals(Http::STATUS_OK, $result->getStatus());
         $this->assertFalse($result->getData()['active']);
+    }
+
+    public function testRefreshedTokenIsActiveAfterOriginalLifetime() {
+        // Regression: a token refreshed via the refresh_token grant keeps its
+        // original `created` timestamp but advances `refreshed`. Introspection
+        // must judge expiry from `refreshed`, otherwise every refreshed token
+        // is reported inactive once the original token's lifetime has elapsed,
+        // breaking token renewal for resource servers that introspect.
+        $client = new Client('test-client', ['https://test.org'], 'RS256');
+        $client->setSecret('test-secret');
+        $client->setClientIdentifier('client123');
+
+        $this->request
+            ->method('getHeader')
+            ->willReturn('Basic ' . base64_encode('test-client:test-secret'));
+
+        $this->clientMapper
+            ->method('getByIdentifier')
+            ->willReturn($client);
+
+        // created is far in the past (well beyond expireTime ago), but the
+        // token was refreshed recently.
+        $accessToken = new AccessToken();
+        $accessToken->setCreated(1000000);     // original issuance, long ago
+        $accessToken->setRefreshed(1005000);   // recently refreshed
+        $accessToken->setUserId('user1');
+        $accessToken->setClientId(1);
+        $accessToken->setScope('openid profile email');
+        $accessToken->setResource('https://resource.example.com');
+
+        $this->accessTokenMapper
+            ->method('getByAccessToken')
+            ->willReturn($accessToken);
+
+        $this->appConfig
+            ->method('getAppValueString')
+            ->willReturn('900'); // 900 seconds expire time
+
+        // now is past created+900 (would be "expired" under the old logic) but
+        // within refreshed+900, so the token is genuinely still valid.
+        $this->time
+            ->method('getTime')
+            ->willReturn(1005500);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('user1');
+
+        $this->userManager
+            ->method('get')
+            ->willReturn($user);
+
+        // Requesting client owns the token.
+        $tokenClient = new Client('token-client', ['https://app.org'], 'RS256');
+        $tokenClient->setClientIdentifier('client123');
+
+        $this->clientMapper
+            ->method('getByUid')
+            ->willReturn($tokenClient);
+
+        $result = $this->controller->introspectToken('refreshed_token');
+
+        $this->assertEquals(Http::STATUS_OK, $result->getStatus());
+        $data = $result->getData();
+        $this->assertTrue($data['active']);
+        // exp must reflect the refreshed-based expiry, not created-based.
+        $this->assertEquals(1005000 + 900, $data['exp']);
     }
 
     public function testClientAuthenticationWithPostBody() {


### PR DESCRIPTION
## Problem

The token introspection endpoint (`IntrospectionController`) computes
access-token expiry as `created + expire_time`:

```php
$tokenExpiryTime = $accessToken->getCreated() + $expireTime;
```

However, the `refresh_token` grant in `OIDCApiController::getToken()` mints a
fresh access token on the **existing** `oc_oidc_access_tokens` row and advances
`refreshed`, but leaves `created` at the original issuance time. (`created` is
set once in `LoginRedirectorController` and never updated thereafter.)

As a consequence, once the **original** token's lifetime has elapsed, every
subsequently refreshed access token is reported `active: false` by
introspection — even though it was just issued and is perfectly valid.

This breaks token renewal for OAuth resource servers that validate bearer
tokens via **introspection** (RFC 7662) rather than the userinfo or JWT path:
after the first token lifetime, the access token can no longer be refreshed
into a usable state, and the client must re-authenticate from scratch.

Every other expiry check in the app already uses `refreshed`:

- `UserInfoController::getUserInfo()` — `getRefreshed() + expire_time`
- `Listener/TokenValidationRequestListener` — `getRefreshed() + expire_time`
- `OIDCApiController::getToken()` (authorization_code) — `getRefreshed() + expire_time`

Introspection was the lone outlier using `created`.

## Fix

Compute introspection expiry from `refreshed + expire_time`, matching the rest
of the app. At initial issuance `created == refreshed`, so freshly issued
(never-refreshed) tokens are unaffected; only refreshed tokens are corrected.
The expired-token log context now also includes `token_refreshed`.

## Tests

- Existing valid-token unit tests now set `refreshed` (== `created`, as a
  freshly issued token does).
- New regression test `testRefreshedTokenIsActiveAfterOriginalLifetime`
  asserts a token whose `created` is past its lifetime but whose `refreshed`
  is recent is reported `active: true` with a refreshed-based `exp`.

## Downstream context

Surfaced via the nextcloud-mcp-server OAuth integration: an MCP client (Mistral)
connected fine initially, but after the access-token lifetime expired,
automated refresh succeeded yet the freshly refreshed token was rejected
(`introspection active=false → 401`), leaving the connector silently unusable.

---

_This PR was generated with the help of AI, and reviewed by a Human_

🤖 Generated with [Claude Code](https://claude.com/claude-code)