### PR TITLE
Fix consent revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.4] - 2026-07-27
+
+### Fixed
+
+- Revoke user consent now invalidates already-issued access tokens and prevents refresh-token grants after consent revocation (fixes [#674](https://github.com/H2CK/oidc/issues/674)).
+- Added regression tests covering consent revocation and refresh token behavior.
+
 ## [2.0.3] - 2026-07-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - Revoke user consent now invalidates already-issued access tokens and prevents refresh-token grants after consent revocation (fixes [#674](https://github.com/H2CK/oidc/issues/674)).
 - Fixed client deletion cleanup so associated `oidc_user_consents` rows are removed and do not remain orphaned.
-- Added regression tests covering consent revocation, refresh token behavior, and client deletion consent cleanup.
+- Fixed a regression in the client edit flow where saving changes could crash with an undefined client list entry when updating the flow type.
+- Added regression tests covering consent revocation, refresh token behavior, client deletion consent cleanup, and the client edit flow.
 
 ## [2.0.3] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Revoke user consent now invalidates already-issued access tokens and prevents refresh-token grants after consent revocation (fixes [#674](https://github.com/H2CK/oidc/issues/674)).
-- Added regression tests covering consent revocation and refresh token behavior.
+- Fixed client deletion cleanup so associated `oidc_user_consents` rows are removed and do not remain orphaned.
+- Added regression tests covering consent revocation, refresh token behavior, and client deletion consent cleanup.
 
 ## [2.0.3] - 2026-07-02
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Full documentation can be found at:
 - [Developer Documentation](https://github.com/H2CK/oidc/wiki#developer-documentation)
 
     ]]></description>
-  <version>2.0.3</version>
+  <version>2.0.4</version>
   <licence>agpl</licence>
   <author mail="dev@jagel.net" homepage="https://github.com/H2CK/oidc">Thorsten Jagel</author>
   <namespace>OIDCIdentityProvider</namespace>

--- a/lib/Controller/ConsentController.php
+++ b/lib/Controller/ConsentController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\OIDCIdentityProvider\Controller;
 
 use OCA\OIDCIdentityProvider\AppInfo\Application;
+use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
 use OCA\OIDCIdentityProvider\Db\UserConsent;
 use OCA\OIDCIdentityProvider\Db\UserConsentMapper;
 use OCA\OIDCIdentityProvider\Db\ClientMapper;
@@ -38,6 +39,8 @@ class ConsentController extends Controller {
     private $userSession;
     /** @var IURLGenerator */
     private $urlGenerator;
+    /** @var AccessTokenMapper */
+    private $accessTokenMapper;
     /** @var UserConsentMapper */
     private $userConsentMapper;
     /** @var ClientMapper */
@@ -58,6 +61,7 @@ class ConsentController extends Controller {
         IUserSession $userSession,
         IURLGenerator $urlGenerator,
         UserConsentMapper $userConsentMapper,
+        AccessTokenMapper $accessTokenMapper,
         ClientMapper $clientMapper,
         ITimeFactory $time,
         IL10N $l,
@@ -69,6 +73,7 @@ class ConsentController extends Controller {
         $this->userSession = $userSession;
         $this->urlGenerator = $urlGenerator;
         $this->userConsentMapper = $userConsentMapper;
+        $this->accessTokenMapper = $accessTokenMapper;
         $this->clientMapper = $clientMapper;
         $this->time = $time;
         $this->l = $l;
@@ -301,6 +306,7 @@ class ConsentController extends Controller {
 
         try {
             $this->userConsentMapper->deleteByUserAndClient($uid, $clientId);
+            $this->accessTokenMapper->deleteByUserAndClient($uid, $clientId);
             $this->logger->info('User ' . $uid . ' revoked consent for client ID: ' . $clientId);
             return new JSONResponse(['success' => true]);
         } catch (\Exception $e) {

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -21,6 +21,7 @@ use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
 use OCA\OIDCIdentityProvider\Db\ClientMapper;
 use OCA\OIDCIdentityProvider\Db\GroupMapper;
 use OCA\OIDCIdentityProvider\Db\Group;
+use OCA\OIDCIdentityProvider\Db\UserConsentMapper;
 use OCA\OIDCIdentityProvider\Exceptions\AccessTokenNotFoundException;
 use OCA\OIDCIdentityProvider\Exceptions\ClientNotFoundException;
 use OCA\OIDCIdentityProvider\Exceptions\JwtCreationErrorException;
@@ -56,6 +57,8 @@ class OIDCApiController extends ApiController {
     private $clientMapper;
     /** @var GroupMapper */
     private $groupMapper;
+    /** @var UserConsentMapper */
+    private $userConsentMapper;
     /** @var ICrypto */
     private $crypto;
     /** @var TokenProvider */
@@ -108,6 +111,7 @@ class OIDCApiController extends ApiController {
                     AuthorizationCodeMapper $authorizationCodeMapper,
                     ClientMapper $clientMapper,
                     GroupMapper $groupMapper,
+                    UserConsentMapper $userConsentMapper,
                     TokenProvider $tokenProvider,
                     ISecureRandom $secureRandom,
                     ITimeFactory $time,
@@ -127,6 +131,7 @@ class OIDCApiController extends ApiController {
         $this->authorizationCodeMapper = $authorizationCodeMapper;
         $this->clientMapper = $clientMapper;
         $this->groupMapper = $groupMapper;
+        $this->userConsentMapper = $userConsentMapper;
         $this->tokenProvider = $tokenProvider;
         $this->secureRandom = $secureRandom;
         $this->time = $time;
@@ -390,6 +395,15 @@ class OIDCApiController extends ApiController {
             $this->accessTokenMapper->delete($accessToken);
             $this->logger->info('Access token used for allowed for user groups. Client id was ' . $client_id . '.');
             return $this->invalidGrantResponse('Access token not allowed for user groups.');
+        }
+
+        if ($grant_type === 'refresh_token') {
+            $userConsent = $this->userConsentMapper->findByUserAndClient($uid, $client->getId());
+            if ($userConsent === null) {
+                $this->accessTokenMapper->delete($accessToken);
+                $this->logger->info('Consent revoked or missing for refresh token grant. Client id was ' . $client_id . '.');
+                return $this->invalidGrantResponse('Consent has been revoked.');
+            }
         }
 
         if ($grant_type === 'authorization_code' && $authorizationCode !== null) {

--- a/lib/Db/AccessTokenMapper.php
+++ b/lib/Db/AccessTokenMapper.php
@@ -115,6 +115,21 @@ class AccessTokenMapper extends QBMapper {
     }
 
     /**
+     * delete all access token for a given user and client
+     *
+     * @param string $userId
+     * @param int $clientId
+     */
+    public function deleteByUserAndClient(string $userId, int $clientId): void {
+        $qb = $this->db->getQueryBuilder();
+        $qb
+            ->delete($this->tableName)
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->andWhere($qb->expr()->eq('client_id', $qb->createNamedParameter($clientId, IQueryBuilder::PARAM_INT)));
+        $qb->executeStatement();
+    }
+
+    /**
      * delete all access token from a given user
      *
      * @param string $id

--- a/lib/Db/ClientMapper.php
+++ b/lib/Db/ClientMapper.php
@@ -16,6 +16,7 @@ use OCA\OIDCIdentityProvider\Db\CustomClaimMapper;
 use OCP\AppFramework\Db\IMapperException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\Server;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Security\ISecureRandom;
@@ -94,6 +95,15 @@ class ClientMapper extends QBMapper {
         }
         // remove custom claims
         $this->customClaimMapper->deleteByClientId($entity->getId());
+
+        // remove user consents referencing this client to avoid orphaned rows
+        try {
+            $userConsentMapper = Server::get(UserConsentMapper::class);
+            $userConsentMapper->deleteByClientId($entity->getId());
+        } catch (\Exception $e) {
+            // log and continue; do not block client deletion on consent cleanup
+            $this->logger->warning('Failed to delete user consents for client '.$entity->getId().': '.$e->getMessage());
+        }
 
         // remove the client
         $entity = parent::delete($entity);
@@ -188,6 +198,14 @@ class ClientMapper extends QBMapper {
         // remove custom claims
         $this->customClaimMapper->deleteByClientId($entity->getId());
 
+        // remove user consents referencing this client to avoid orphaned rows
+        try {
+            $userConsentMapper = Server::get(UserConsentMapper::class);
+            $userConsentMapper->deleteByClientId($entity->getId());
+        } catch (\Exception $e) {
+            $this->logger->warning('Failed to delete user consents for client '.$entity->getId().': '.$e->getMessage());
+        }
+
         $qb = $this->db->getQueryBuilder();
         $qb
             ->delete($this->tableName)
@@ -221,6 +239,13 @@ class ClientMapper extends QBMapper {
             $this->redirectUriMapper->deleteByClientId($entity->getId());
             // remove custom claims
             $this->customClaimMapper->deleteByClientId($entity->getId());
+            // remove user consents referencing this client
+            try {
+                $userConsentMapper = Server::get(UserConsentMapper::class);
+                $userConsentMapper->deleteByClientId($entity->getId());
+            } catch (\Exception $e) {
+                $this->logger->warning('Failed to delete user consents for client '.$entity->getId().': '.$e->getMessage());
+            }
         }
 
         $qb = $this->db->getQueryBuilder();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "oidc",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "oidc",
-			"version": "2.0.3",
+			"version": "2.0.4",
 			"license": "agpl",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "oidc",
 	"description": "Use Nextcloud as OIDC Identity Provider",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"author": "Thorsten Jagel <dev@jagel.net>",
 	"bugs": {
 		"url": "https://github.com/H2CK/oidc/issues"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1473,22 +1473,25 @@ export default {
 		},
 		async updateFlowTypes() {
 			const id = this.editClient.id
+			const flowType = this.editClient.flowData.props.value[0].value
 			await axios.patch(
 				generateUrl('apps/oidc/clients/flows/{id}', { id }),
 				{
 					id,
-					flowType: this.editClient.flowData.props.value[0].value,
+					flowType,
 				},
 			).then(response => {
-				// Update local clients list with changed data
-				this.localClients = this.localClients.filter(client => client.id !== id)
-				this.localClients[0].flowType = this.editClient.flowData.props.value[0].value
-				if (this.editClient.flowData.props.value[0].value === 'code') {
-					this.localClients[0].flowTypeLabel = t('oidc', 'Code Authorization Flow')
-				} else {
-					this.localClients[0].flowTypeLabel = t('oidc', 'Code & Implicit Authorization Flow')
+				// Update the edited client in local state without depending on array position
+				const clientIndex = this.localClients.findIndex(c => c.id === id)
+				if (clientIndex !== -1) {
+					this.localClients[clientIndex].flowType = flowType
+					if (flowType === 'code') {
+						this.localClients[clientIndex].flowTypeLabel = t('oidc', 'Code Authorization Flow')
+					} else {
+						this.localClients[clientIndex].flowTypeLabel = t('oidc', 'Code & Implicit Authorization Flow')
+					}
+					this.version += 1
 				}
-				this.version += 1
 			}).catch(error_ => {
 				this.error = true
 				this.errorMsg = this.extractErrorMessage(error_)

--- a/tests/Integration/OIDCCodeFlowTest.php
+++ b/tests/Integration/OIDCCodeFlowTest.php
@@ -12,6 +12,7 @@ namespace OCA\OIDCIdentityProvider\Tests\Integration;
 use OCA\OIDCIdentityProvider\AppInfo\Application;
 use OCA\OIDCIdentityProvider\Db\Client;
 use OCA\OIDCIdentityProvider\Db\ClientMapper;
+use OCA\OIDCIdentityProvider\Db\UserConsent;
 use OCA\OIDCIdentityProvider\Db\AccessToken;
 use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
 use OCA\OIDCIdentityProvider\Db\AuthorizationCodeMapper;
@@ -763,6 +764,26 @@ class OIDCCodeFlowTest extends \Test\TestCase
         $responseData = $userInfoResponse->getData();
         $this->assertArrayHasKey('error', $responseData, 'Response missing error field');
         $this->assertEquals('invalid_request', $responseData['error'], 'Error should be invalid_request');
+    }
+
+    public function testDeletingClientRemovesUserConsents(): void
+    {
+        $client = $this->createTestClient();
+        $user = $this->createTestUser();
+
+        $consent = new UserConsent();
+        $consent->setUserId($user->getUID());
+        $consent->setClientId($client->getId());
+        $consent->setScopesGranted('openid profile email');
+        $consent->setCreatedAt($this->time->getTime());
+        $consent->setUpdatedAt($this->time->getTime());
+        $consent->setExpiresAt($this->time->getTime() + 7776000);
+        $this->userConsentMapper->insert($consent);
+
+        $this->clientMapper->delete($client);
+
+        $remainingConsent = $this->userConsentMapper->findByUserAndClient($user->getUID(), $client->getId());
+        $this->assertNull($remainingConsent, 'User consent should be deleted when the client is deleted');
     }
 
     /**

--- a/tests/Integration/OIDCCodeFlowTest.php
+++ b/tests/Integration/OIDCCodeFlowTest.php
@@ -45,7 +45,7 @@ use OC\Security\Ip\BruteforceAllowList;
 use OC\Security\SecureRandom;
 use OCP\AppFramework\Http\JSONResponse;
 use Psr\Log\LoggerInterface;
-use OCP\L10N\IFactory AS L10nFactory;
+use OCP\L10N\IFactory as L10nFactory;
 
 /**
  * Integration test for the OpenID Connect code flow.
@@ -113,8 +113,14 @@ class OIDCCodeFlowTest extends \Test\TestCase
     /** @var IAppConfig */
     private $appConfig;
 
-    /** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var mixed */
     private $request;
+
+    /** @var IConfig */
+    private $config;
+
+    /** @var IProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $tokenProvider;
 
     /** @var string */
     private $testUserId = 'test-oidc-user';
@@ -137,7 +143,7 @@ class OIDCCodeFlowTest extends \Test\TestCase
     /** @var \OCP\AppFramework\App */
     private $app;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|IL10NFactory */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|L10nFactory */
     private $lFactory;
 
     protected function setUp(): void
@@ -196,7 +202,7 @@ class OIDCCodeFlowTest extends \Test\TestCase
         $customClaimMapper = Server::get(\OCA\OIDCIdentityProvider\Db\CustomClaimMapper::class);
         $userConfig = Server::get(\OCP\Config\IUserConfig::class);
 
-        $this->lFactory = $this->createMock(l10NFactory::class);
+        $this->lFactory = $this->createMock(L10nFactory::class);
 
         $customClaimService = new \OCA\OIDCIdentityProvider\Service\CustomClaimService(
             $customClaimMapper,
@@ -236,7 +242,6 @@ class OIDCCodeFlowTest extends \Test\TestCase
         $this->request = $this->createMock(IRequest::class);
         $this->request->method('getServerProtocol')->willReturn('https');
         $this->request->method('getServerHost')->willReturn('nextcloud.local');
-        $this->request->server = [];
 
         $this->oidcApiController = new OIDCApiController(
             'oidc',
@@ -246,6 +251,7 @@ class OIDCCodeFlowTest extends \Test\TestCase
             $this->authorizationCodeMapper,
             $this->clientMapper,
             $this->groupMapper,
+            $this->userConsentMapper,
             $this->tokenProvider,
             $this->secureRandom,
             $this->time,
@@ -438,7 +444,6 @@ class OIDCCodeFlowTest extends \Test\TestCase
 
         // Set up the request to include the Authorization header
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $accessTokenString;
-        $this->request->server['HTTP_AUTHORIZATION'] = 'Bearer ' . $accessTokenString;
 
         $userInfoResponse = $this->userInfoController->getInfo();
 
@@ -614,7 +619,6 @@ class OIDCCodeFlowTest extends \Test\TestCase
         $this->assertEquals('invalid_grant', $secondResponseData['error'], 'Reuse response should be invalid_grant');
 
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $firstResponseData['access_token'];
-        $this->request->server['HTTP_AUTHORIZATION'] = 'Bearer ' . $firstResponseData['access_token'];
 
         $userInfoResponse = $this->userInfoController->getInfo();
         $this->assertEquals(400, $userInfoResponse->getStatus(), 'Reused code should revoke the issued access token');
@@ -685,6 +689,43 @@ class OIDCCodeFlowTest extends \Test\TestCase
         $this->assertEquals('invalid_grant', $responseData['error'], 'Error should be invalid_grant');
     }
 
+    public function testRefreshTokenFailsAfterConsentRevocation(): void
+    {
+        $client = $this->createTestClient();
+        $user = $this->createTestUser();
+
+        $tokenResult = $this->createAccessToken($client, $user, 'openid offline_access', false);
+        $refreshToken = $tokenResult['rawCode'];
+
+        $consent = new \OCA\OIDCIdentityProvider\Db\UserConsent();
+        $consent->setUserId($user->getUID());
+        $consent->setClientId($client->getId());
+        $consent->setScopesGranted('openid offline_access');
+        $consent->setCreatedAt($this->time->getTime());
+        $consent->setUpdatedAt($this->time->getTime());
+        $consent->setExpiresAt($this->time->getTime() + 7776000);
+        $this->userConsentMapper->insert($consent);
+
+        // Revoke consent for the user and client
+        $this->userConsentMapper->deleteByUserAndClient($user->getUID(), $client->getId());
+
+        $response = $this->oidcApiController->getToken(
+            'refresh_token',
+            null,
+            $refreshToken,
+            $this->testClientId,
+            $this->testClientSecret,
+            null
+        );
+
+        $this->assertInstanceOf(JSONResponse::class, $response, 'Response is not a JSONResponse');
+        $this->assertEquals(400, $response->getStatus(), 'Refresh token grant should fail after consent revocation');
+
+        $responseData = $response->getData();
+        $this->assertArrayHasKey('error', $responseData, 'Response missing error field');
+        $this->assertEquals('invalid_grant', $responseData['error'], 'Error should be invalid_grant');
+    }
+
     /**
      * Test user info with invalid access token
      */
@@ -712,7 +753,6 @@ class OIDCCodeFlowTest extends \Test\TestCase
     {
         // Clear any existing auth header
         unset($_SERVER['HTTP_AUTHORIZATION']);
-        $this->request->server = [];
 
         $userInfoResponse = $this->userInfoController->getInfo();
 

--- a/tests/Integration/OIDCImplicitFlowTest.php
+++ b/tests/Integration/OIDCImplicitFlowTest.php
@@ -14,6 +14,7 @@ use OCA\OIDCIdentityProvider\Db\ClientMapper;
 use OCA\OIDCIdentityProvider\Db\AccessToken;
 use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
 use OCA\OIDCIdentityProvider\Db\AuthorizationCodeMapper;
+use OCA\OIDCIdentityProvider\Db\UserConsentMapper;
 use OCA\OIDCIdentityProvider\Db\GroupMapper;
 use OCA\OIDCIdentityProvider\Controller\OIDCApiController;
 use OCA\OIDCIdentityProvider\Controller\UserInfoController;
@@ -34,7 +35,7 @@ use OC\Security\Ip\BruteforceAllowList;
 use OC\Security\SecureRandom;
 use OCP\AppFramework\Http\JSONResponse;
 use Psr\Log\LoggerInterface;
-use OCP\L10N\IFactory AS L10nFactory;
+use OCP\L10N\IFactory as L10nFactory;
 
 /**
  * Integration test for the OpenID Connect implicit flow.
@@ -91,11 +92,17 @@ class OIDCImplicitFlowTest extends \Test\TestCase
     /** @var UserInfoController */
     private $userInfoController;
 
-    /** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var mixed */
     private $request;
 
     /** @var IConfig */
     private $config;
+
+    /** @var IProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $tokenProvider;
+
+    /** @var UserConsentMapper */
+    private $userConsentMapper;
 
     /** @var string */
     private $testUserId = 'test-implicit-user';
@@ -112,7 +119,7 @@ class OIDCImplicitFlowTest extends \Test\TestCase
     /** @var \OCP\AppFramework\App */
     private $app;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|IL10NFactory */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|L10nFactory */
     private $lFactory;
 
     protected function setUp(): void
@@ -162,12 +169,15 @@ class OIDCImplicitFlowTest extends \Test\TestCase
 
         // Get app-specific services from the app container
         $tokenProvider = $appContainer->get(IProvider::class);
+        $this->tokenProvider = $tokenProvider;
+
+        $this->userConsentMapper = Server::get(UserConsentMapper::class);
 
         // Get JwtGenerator and other app services
         $customClaimMapper = Server::get(\OCA\OIDCIdentityProvider\Db\CustomClaimMapper::class);
         $userConfig = Server::get(\OCP\Config\IUserConfig::class);
 
-        $this->lFactory = $this->createMock(l10NFactory::class);
+        $this->lFactory = $this->createMock(L10nFactory::class);
 
         $customClaimService = new \OCA\OIDCIdentityProvider\Service\CustomClaimService(
             $customClaimMapper,
@@ -207,7 +217,6 @@ class OIDCImplicitFlowTest extends \Test\TestCase
         $this->request = $this->createMock(IRequest::class);
         $this->request->method('getServerProtocol')->willReturn('https');
         $this->request->method('getServerHost')->willReturn('nextcloud.local');
-        $this->request->server = [];
 
         $this->oidcApiController = new OIDCApiController(
             'oidc',
@@ -217,6 +226,7 @@ class OIDCImplicitFlowTest extends \Test\TestCase
             $this->authorizationCodeMapper,
             $this->clientMapper,
             $this->groupMapper,
+            $this->userConsentMapper,
             $tokenProvider,
             $this->secureRandom,
             $this->time,
@@ -380,7 +390,6 @@ class OIDCImplicitFlowTest extends \Test\TestCase
 
         // Step 4: Use the access token to get user info (simulating implicit flow token usage)
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $rawToken;
-        $this->request->server['HTTP_AUTHORIZATION'] = 'Bearer ' . $rawToken;
 
         $userInfoResponse = $this->userInfoController->getInfo();
 

--- a/tests/Unit/Controller/ConsentControllerTest.php
+++ b/tests/Unit/Controller/ConsentControllerTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 use OCA\OIDCIdentityProvider\Controller\ConsentController;
 use OCA\OIDCIdentityProvider\Db\UserConsent;
 use OCA\OIDCIdentityProvider\Db\UserConsentMapper;
+use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
+use OCA\OIDCIdentityProvider\AppInfo\Application;
 use OCA\OIDCIdentityProvider\Db\ClientMapper;
 use OCA\OIDCIdentityProvider\Db\Client;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -33,6 +35,8 @@ class ConsentControllerTest extends TestCase {
     protected $urlGenerator;
     /** @var \PHPUnit\Framework\MockObject\MockObject|UserConsentMapper */
     protected $userConsentMapper;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|AccessTokenMapper */
+    protected $accessTokenMapper;
     /** @var \PHPUnit\Framework\MockObject\MockObject|ClientMapper */
     protected $clientMapper;
     /** @var \PHPUnit\Framework\MockObject\MockObject|ITimeFactory */
@@ -54,6 +58,7 @@ class ConsentControllerTest extends TestCase {
         $this->userSession = $this->createMock(IUserSession::class);
         $this->urlGenerator = $this->createMock(IURLGenerator::class);
         $this->userConsentMapper = $this->createMock(UserConsentMapper::class);
+        $this->accessTokenMapper = $this->createMock(AccessTokenMapper::class);
         $this->clientMapper = $this->createMock(ClientMapper::class);
         $this->time = $this->createMock(ITimeFactory::class);
         $this->l = $this->createMock(IL10N::class);
@@ -72,6 +77,7 @@ class ConsentControllerTest extends TestCase {
             $this->userSession,
             $this->urlGenerator,
             $this->userConsentMapper,
+            $this->accessTokenMapper,
             $this->clientMapper,
             $this->time,
             $this->l,
@@ -120,6 +126,32 @@ class ConsentControllerTest extends TestCase {
         $params = $response->getParams();
         $this->assertEquals('Test Client', $params['clientName']);
         $this->assertEquals('openid profile email', $params['requestedScopes']);
+    }
+
+    public function testRevokeConsentDeletesAccessTokens(): void {
+        $this->userSession->method('isLoggedIn')->willReturn(true);
+        $this->user->method('getUID')->willReturn('testuser');
+        $this->userSession->method('getUser')->willReturn($this->user);
+
+        $this->appConfig->method('getAppValueString')
+            ->with(
+                Application::APP_CONFIG_ALLOW_USER_SETTINGS,
+                Application::DEFAULT_ALLOW_USER_SETTINGS
+            )
+            ->willReturn('yes');
+
+        $this->userConsentMapper->expects($this->once())
+            ->method('deleteByUserAndClient')
+            ->with('testuser', 1);
+
+        $this->accessTokenMapper->expects($this->once())
+            ->method('deleteByUserAndClient')
+            ->with('testuser', 1);
+
+        $response = $this->controller->revokeConsent(1);
+
+        $this->assertEquals(200, $response->getStatus());
+        $this->assertEquals(['success' => true], $response->getData());
     }
 
     public function testGrantSuccess() {


### PR DESCRIPTION
Revoke user consent now invalidates already-issued access tokens and prevents refresh-token grants after consent revocation