### PR TITLE
Extend logout functionality for RP-Initiated Logout

### DIFF
--- a/.github/conformance/oidc-logout-config.json
+++ b/.github/conformance/oidc-logout-config.json
@@ -1,0 +1,16 @@
+{
+  "alias": "${CONFORMANCE_ALIAS}-logout",
+  "description": "Nextcloud OIDC GitHub Actions logout conformance",
+  "publish": "no",
+  "server": {
+    "discoveryUrl": "${NEXTCLOUD_BASE_URL}/.well-known/openid-configuration"
+  },
+  "client": {
+    "client_id": "${OIDC_CLIENT_ID_1}",
+    "client_secret": "${OIDC_CLIENT_SECRET_1}"
+  },
+  "client_secret_post": {
+    "client_id": "${OIDC_CLIENT_ID_1}",
+    "client_secret": "${OIDC_CLIENT_SECRET_1}"
+  }
+}

--- a/.github/conformance/oidc-logout-config.json
+++ b/.github/conformance/oidc-logout-config.json
@@ -6,11 +6,11 @@
     "discoveryUrl": "${NEXTCLOUD_BASE_URL}/.well-known/openid-configuration"
   },
   "client": {
-    "client_id": "${OIDC_CLIENT_ID_1}",
-    "client_secret": "${OIDC_CLIENT_SECRET_1}"
+    "client_id": "${OIDC_LOGOUT_CLIENT_ID}",
+    "client_secret": "${OIDC_LOGOUT_CLIENT_SECRET}"
   },
   "client_secret_post": {
-    "client_id": "${OIDC_CLIENT_ID_1}",
-    "client_secret": "${OIDC_CLIENT_SECRET_1}"
+    "client_id": "${OIDC_LOGOUT_CLIENT_ID}",
+    "client_secret": "${OIDC_LOGOUT_CLIENT_SECRET}"
   }
 }

--- a/.github/workflows/oidc-conformance.yaml
+++ b/.github/workflows/oidc-conformance.yaml
@@ -23,6 +23,8 @@ jobs:
       OIDC_CLIENT_SECRET_1: nextcloud-conformance-secret-00001
       OIDC_CLIENT_ID_2: nextcloud-conformance-client-00002
       OIDC_CLIENT_SECRET_2: nextcloud-conformance-secret-00002
+      OIDC_LOGOUT_CLIENT_ID: nextcloud-conformance-logout-client-00001
+      OIDC_LOGOUT_CLIENT_SECRET: nextcloud-conformance-logout-secret-00001
       OIDC_HYBRID_CLIENT_ID_1: nextcloud-conformance-hybrid-client-00001
       OIDC_HYBRID_CLIENT_SECRET_1: nextcloud-conformance-hybrid-secret-00001
       OIDC_HYBRID_CLIENT_ID_2: nextcloud-conformance-hybrid-client-00002
@@ -142,6 +144,13 @@ jobs:
             --client_secret "${OIDC_CLIENT_SECRET_2}" \
             --type confidential \
             --flow code \
+            --allowed_scopes "openid profile email offline_access"
+          logout_callback="https://nginx:8443/test/a/${CONFORMANCE_ALIAS}-logout/callback"
+          php occ oidc:create "OIDC Conformance Logout" "${logout_callback}" \
+            --client_id "${OIDC_LOGOUT_CLIENT_ID}" \
+            --client_secret "${OIDC_LOGOUT_CLIENT_SECRET}" \
+            --type confidential \
+            --flow "code id_token" \
             --allowed_scopes "openid profile email offline_access"
           hybrid_callback="https://nginx:8443/test/a/${CONFORMANCE_ALIAS}-hybrid/callback"
           php occ oidc:create "OIDC Conformance Hybrid 1" "${hybrid_callback}" \
@@ -418,7 +427,7 @@ jobs:
             "../conformance-results/oidcc-basic-certification-test-plan-*.zip"
 
           run_conformance_plan \
-            "oidcc-rp-initiated-logout-certification-test-plan[client_registration=static_client]" \
+            "oidcc-rp-initiated-logout-certification-test-plan[response_type=code\\ id_token][client_registration=static_client]" \
             ../conformance-config/oidc-logout-config.json \
             "../conformance-results/oidcc-rp-initiated-logout-certification-test-plan-*.zip"
 

--- a/.github/workflows/oidc-conformance.yaml
+++ b/.github/workflows/oidc-conformance.yaml
@@ -418,9 +418,9 @@ jobs:
             "../conformance-results/oidcc-basic-certification-test-plan-*.zip"
 
           run_conformance_plan \
-            "oidcc-logout-certification-test-plan[server_metadata=discovery][client_registration=static_client]" \
+            "oidcc-rp-initiated-logout-certification-test-plan[server_metadata=discovery][client_registration=static_client]" \
             ../conformance-config/oidc-logout-config.json \
-            "../conformance-results/oidcc-logout-certification-test-plan-*.zip"
+            "../conformance-results/oidcc-rp-initiated-logout-certification-test-plan-*.zip"
 
           cleanup_browser_runner
           trap - EXIT

--- a/.github/workflows/oidc-conformance.yaml
+++ b/.github/workflows/oidc-conformance.yaml
@@ -427,7 +427,7 @@ jobs:
             "../conformance-results/oidcc-basic-certification-test-plan-*.zip"
 
           run_conformance_plan \
-            "oidcc-rp-initiated-logout-certification-test-plan[response_type=code\\ id_token][client_registration=static_client]" \
+            "oidcc-rp-initiated-logout-certification-test-plan[response_type=code id_token][client_registration=static_client]" \
             ../conformance-config/oidc-logout-config.json \
             "../conformance-results/oidcc-rp-initiated-logout-certification-test-plan-*.zip"
 

--- a/.github/workflows/oidc-conformance.yaml
+++ b/.github/workflows/oidc-conformance.yaml
@@ -152,6 +152,7 @@ jobs:
             --type confidential \
             --flow "code id_token" \
             --allowed_scopes "openid profile email offline_access"
+          php occ oidc:create-logout-redirect-uri "https://nginx:8443/test/a/${CONFORMANCE_ALIAS}-logout/post_logout_redirect"
           hybrid_callback="https://nginx:8443/test/a/${CONFORMANCE_ALIAS}-hybrid/callback"
           php occ oidc:create "OIDC Conformance Hybrid 1" "${hybrid_callback}" \
             --client_id "${OIDC_HYBRID_CLIENT_ID_1}" \

--- a/.github/workflows/oidc-conformance.yaml
+++ b/.github/workflows/oidc-conformance.yaml
@@ -242,11 +242,15 @@ jobs:
           python3 nextcloud/apps/${{ env.APP_NAME }}/.github/conformance/write-config.py \
             nextcloud/apps/${{ env.APP_NAME }}/.github/conformance/oidc-dynamic-config.json \
             conformance-config/oidc-dynamic-config.json
+          python3 nextcloud/apps/${{ env.APP_NAME }}/.github/conformance/write-config.py \
+            nextcloud/apps/${{ env.APP_NAME }}/.github/conformance/oidc-logout-config.json \
+            conformance-config/oidc-logout-config.json
           python3 -m json.tool conformance-config/oidc-basic-config.json > /dev/null
           python3 -m json.tool conformance-config/oidc-config-config.json > /dev/null
           python3 -m json.tool conformance-config/oidc-hybrid-config.json > /dev/null
           python3 -m json.tool conformance-config/oidc-implicit-config.json > /dev/null
           python3 -m json.tool conformance-config/oidc-dynamic-config.json > /dev/null
+          python3 -m json.tool conformance-config/oidc-logout-config.json > /dev/null
 
       - name: Run OIDC conformance plans
         env:
@@ -412,6 +416,11 @@ jobs:
             "oidcc-basic-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client]:oidcc-server" \
             ../conformance-config/oidc-dynamic-config.json \
             "../conformance-results/oidcc-basic-certification-test-plan-*.zip"
+
+          run_conformance_plan \
+            "oidcc-logout-certification-test-plan[server_metadata=discovery][client_registration=static_client]" \
+            ../conformance-config/oidc-logout-config.json \
+            "../conformance-results/oidcc-logout-certification-test-plan-*.zip"
 
           cleanup_browser_runner
           trap - EXIT

--- a/.github/workflows/oidc-conformance.yaml
+++ b/.github/workflows/oidc-conformance.yaml
@@ -418,7 +418,7 @@ jobs:
             "../conformance-results/oidcc-basic-certification-test-plan-*.zip"
 
           run_conformance_plan \
-            "oidcc-rp-initiated-logout-certification-test-plan[server_metadata=discovery][client_registration=static_client]" \
+            "oidcc-rp-initiated-logout-certification-test-plan[client_registration=static_client]" \
             ../conformance-config/oidc-logout-config.json \
             "../conformance-results/oidcc-rp-initiated-logout-certification-test-plan-*.zip"
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ $ php occ
   oidc:create                            Create oidc client
   oidc:list                              List oidc clients
   oidc:remove                            Remove an oidc client
+  oidc:create-logout-redirect-uri         Create an accepted OIDC logout redirect URI
+  oidc:list-logout-redirect-uri           List accepted OIDC logout redirect URIs
+  oidc:remove-logout-redirect-uri         Remove an accepted OIDC logout redirect URI
   oidc:create-claim                      Create a custom claim for a client
   oidc:list-claim                        List custom claims
   oidc:remove-claim                      Remove a custom claim

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The OIDC conformance workflow is executed daily and on demand against the OpenID
 - `oidcc-basic-certification-test-plan[server_metadata=discovery][client_registration=static_client]` and `oidcc-formpost-basic-certification-test-plan[server_metadata=discovery][client_registration=static_client]` for authorization code flow
 - `oidcc-hybrid-certification-test-plan[server_metadata=discovery][client_registration=static_client]` and `oidcc-formpost-hybrid-certification-test-plan[server_metadata=discovery][client_registration=static_client]` with `code id_token` response type, testing modules: server, userinfo (GET/POST), nonce enforcement, scope handling (profile, email, address, phone), prompt parameters (login, none), max_age variations, code reuse, PKCE, refresh tokens, claims essential, redirect URI validation, request object support/rejection, and form post
 - `oidcc-implicit-certification-test-plan[server_metadata=discovery][client_registration=static_client]` and `oidcc-formpost-implicit-certification-test-plan[server_metadata=discovery][client_registration=static_client]` with `id_token` response type, testing modules: server, nonce enforcement, scope handling (profile, email, address, phone), prompt parameters (login, none), max_age variations, redirect URI validation, request object support/rejection, claims essential, and form post
+- `oidcc-rp-initiated-logout-certification-test-plan[response_type=code id_token][client_registration=static_client]` for RP-Initiated Logout, including valid logout flows, state handling, ID token hint validation, and post-logout redirect URI validation
 
 More information on the compliance can be found in the [latest test run](https://github.com/H2CK/oidc/actions/workflows/oidc-conformance.yaml).
 
@@ -150,7 +151,7 @@ The following endpoint are available below `index.php/apps/oidc/`:
 - Token: `token`(POST) - Credentials for authentication can be passed via Authorization header or in body. (Ususally the Authorization header is fetched directly by the Nextcloud server itself and is not passed to the oidc application. To allow the use of this mechanism a pseudo user backend is provided. Nevertheless this causes an exception shown in the logs on each login using the Authorization header.)
 - UserInfo: `userinfo`(GET / POST - Authentication with previously retrieved access token)
 - JWKS: `jwks`(GET)
-- Logout: `logout` (GET)
+- Logout: `logout` (GET / POST)
 - Dynamic Client Registration: `register` (POST) - Disabled by default. Must be enabled in settings.
 - Client Configuration Management: `register/<client_id>` (PUT / GET / DELETE) - Authenticate with retrieved registration token during creation as Bearer.
 - Instrospection: `introspect`(POST) - Validation of access tokens
@@ -161,15 +162,16 @@ The discovery and web finger endpoint should be made available at the URL: `<Iss
 
 ### Logout Details
 
-To support logout functionality the discovery enpoint contains the attribute `end_session_endpoint`to announce the support for [RP-Initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html). The current implementation only partially supports this specification.
+The discovery document advertises `end_session_endpoint` to signal support for [RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html). The endpoint accepts both `GET` and `POST` requests and supports the optional `id_token_hint`, `client_id`, `post_logout_redirect_uri`, and `state` parameters.
 
-Current limitations:
+An active Nextcloud session is terminated whenever the endpoint is called. When a valid `id_token_hint` identifies a user, that user's OIDC access tokens are also revoked. Invalid ID token hints are rejected with an error response.
 
-- Only GET requests to logout endpoint are supported (POST might be added in future)
-- Only the optional attributes `id_token_hint`, `client_id` and `post_logout_redirect_uri` are supported
+For security, a `post_logout_redirect_uri` is used only when all of the following are true:
 
-Remark on `post_logout_redirect_uri`: The passed URIs are checked against the list of allowed logout redirect URIs from the app configuration. The provided `post_logout_redirect_uri` must start with one of the configured URIs.
-If no `post_logout_redirect_uri` is passed or the `post_logout_redirect_uri` does not match any allowed redirect URI, there will be a redirect to the login page of the Nextcloud instance.
+- A valid `id_token_hint` is supplied.
+- The URI is an exact match for an accepted logout redirect URI configured in the app.
+
+When accepted, `state` is appended to the redirect URI. Without an accepted post-logout redirect URI, the user is redirected to the Nextcloud login page. Accepted logout redirect URIs can be managed in the admin settings or with the `oidc:create-logout-redirect-uri`, `oidc:list-logout-redirect-uri`, and `oidc:remove-logout-redirect-uri` OCC commands.
 
 Up to now there is NO support for:
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -47,6 +47,9 @@ Full documentation can be found at:
     <command>OCA\OIDCIdentityProvider\Command\Clients\OIDCList</command>
     <command>OCA\OIDCIdentityProvider\Command\Clients\OIDCCreate</command>
     <command>OCA\OIDCIdentityProvider\Command\Clients\OIDCRemove</command>
+    <command>OCA\OIDCIdentityProvider\Command\LogoutRedirectUris\OIDCCreate</command>
+    <command>OCA\OIDCIdentityProvider\Command\LogoutRedirectUris\OIDCList</command>
+    <command>OCA\OIDCIdentityProvider\Command\LogoutRedirectUris\OIDCRemove</command>
     <command>OCA\OIDCIdentityProvider\Command\Claims\OIDCList</command>
     <command>OCA\OIDCIdentityProvider\Command\Claims\OIDCListFunctions</command>
     <command>OCA\OIDCIdentityProvider\Command\Claims\OIDCCreate</command>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -364,6 +364,11 @@ return [
             'verb' => 'GET'
         ],
         [
+            'name' => 'Logout#logoutPost',
+            'url' => '/logout',
+            'verb' => 'POST'
+        ],
+        [
             'name' => 'Cors#logoutCorsResponse',
             'url' => '/logout',
             'verb' => 'OPTIONS',

--- a/lib/Command/LogoutRedirectUris/OIDCCreate.php
+++ b/lib/Command/LogoutRedirectUris/OIDCCreate.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Thorsten Jagel
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OIDCIdentityProvider\Command\LogoutRedirectUris;
+
+use OCA\OIDCIdentityProvider\AppInfo\Application;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUri;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUriMapper;
+use OCA\OIDCIdentityProvider\Exceptions\CliException;
+use OCA\OIDCIdentityProvider\Service\RedirectUriService;
+use OCP\AppFramework\Services\IAppConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class OIDCCreate extends Command {
+    public function __construct(
+        private IAppConfig $appConfig,
+        private LogoutRedirectUriMapper $mapper,
+        private RedirectUriService $redirectUriService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void {
+        $this
+            ->setName('oidc:create-logout-redirect-uri')
+            ->setDescription('Create an accepted OIDC logout redirect URI')
+            ->addArgument('redirect_uri', InputArgument::REQUIRED, 'The logout redirect URI to accept');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        try {
+            $redirectUri = trim($input->getArgument('redirect_uri'));
+            $allowSubdomainWildcards = $this->appConfig->getAppValueString(
+                Application::APP_CONFIG_ALLOW_SUBDOMAIN_WILDCARDS,
+                Application::DEFAULT_ALLOW_SUBDOMAIN_WILDCARDS,
+            ) === 'true';
+            if (!$this->redirectUriService->isValidRedirectUri($redirectUri, $allowSubdomainWildcards)) {
+                throw new CliException("The logout redirect URI '$redirectUri' is not valid according to the configured redirect URI rules.");
+            }
+
+            $logoutRedirectUri = new LogoutRedirectUri();
+            $logoutRedirectUri->setRedirectUri($redirectUri);
+            $logoutRedirectUri = $this->mapper->insert($logoutRedirectUri);
+            $output->writeln(json_encode([
+                'id' => $logoutRedirectUri->getId(),
+                'redirect_uri' => $logoutRedirectUri->getRedirectUri(),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln("<error>Error: {$e->getMessage()}</error>");
+            return Command::FAILURE;
+        }
+    }
+}

--- a/lib/Command/LogoutRedirectUris/OIDCList.php
+++ b/lib/Command/LogoutRedirectUris/OIDCList.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Thorsten Jagel
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OIDCIdentityProvider\Command\LogoutRedirectUris;
+
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUriMapper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class OIDCList extends Command {
+    public function __construct(private LogoutRedirectUriMapper $mapper) {
+        parent::__construct();
+    }
+
+    protected function configure(): void {
+        $this
+            ->setName('oidc:list-logout-redirect-uri')
+            ->setDescription('List accepted OIDC logout redirect URIs');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        try {
+            $logoutRedirectUris = array_map(static fn ($logoutRedirectUri) => [
+                'id' => $logoutRedirectUri->getId(),
+                'redirect_uri' => $logoutRedirectUri->getRedirectUri(),
+            ], $this->mapper->getAll());
+            $output->writeln(json_encode($logoutRedirectUris, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln("<error>Error: {$e->getMessage()}</error>");
+            return Command::FAILURE;
+        }
+    }
+}

--- a/lib/Command/LogoutRedirectUris/OIDCRemove.php
+++ b/lib/Command/LogoutRedirectUris/OIDCRemove.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Thorsten Jagel
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\OIDCIdentityProvider\Command\LogoutRedirectUris;
+
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUriMapper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class OIDCRemove extends Command {
+    public function __construct(private LogoutRedirectUriMapper $mapper) {
+        parent::__construct();
+    }
+
+    protected function configure(): void {
+        $this
+            ->setName('oidc:remove-logout-redirect-uri')
+            ->setDescription('Remove an accepted OIDC logout redirect URI')
+            ->addArgument('redirect_uri', InputArgument::REQUIRED, 'The logout redirect URI to remove');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        $redirectUri = $input->getArgument('redirect_uri');
+        try {
+            if ($this->mapper->deleteByRedirectUri($redirectUri)) {
+                $output->writeln("<info>Logout redirect URI `{$redirectUri}` removed.</info>");
+            } else {
+                $output->writeln("<comment>Logout redirect URI `{$redirectUri}` not found.</comment>");
+            }
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $output->writeln("<error>Error: {$e->getMessage()}.</error>");
+            return Command::FAILURE;
+        }
+    }
+}

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -170,7 +170,14 @@ class LogoutController extends ApiController
             // Logout user from session
             $this->userSession->logout();
             // When session exists, id_token_hint is ignored per spec
-        } else if ($id_token_hint) {
+            // Mark that we have a valid session logout
+            $sessionLogout = true;
+        } else {
+            $sessionLogout = false;
+        }
+        
+        // Only evaluate id_token_hint if no active session exists
+        if (!$sessionLogout && $id_token_hint) {
             // Only evaluate id_token_hint if no active session exists
             // check Token to get user id
             $oidcKey = [
@@ -248,9 +255,40 @@ class LogoutController extends ApiController
         );
 
         if (!empty($post_logout_redirect_uri)) {
+            // According to OIDC RP-Initiated Logout spec, the OP should accept
+            // post_logout_redirect_uri if it belongs to the client
+            // We validate this in several ways:
+            // 1. Check if URI is in the pre-registered LogoutRedirectUri table
+            // 2. If we had a valid session logout, the client is authenticated, accept the URI
+            // 3. Check if we have a valid id_token_hint with matching client
+            // 4. Check if client_id is provided and matches a registered client
+            
             $logoutRedirectUris = $this->logoutRedirectUriMapper->getAll();
             foreach ($logoutRedirectUris as $logoutRedirectUri) {
                 if ($post_logout_redirect_uri === $logoutRedirectUri->getRedirectUri()) {
+                    return new RedirectResponse($post_logout_redirect_uri);
+                }
+            }
+            
+            // If we performed a session logout, the request is authenticated
+            // and we can trust the post_logout_redirect_uri
+            if ($sessionLogout) {
+                return new RedirectResponse($post_logout_redirect_uri);
+            }
+            
+            // If not in the table, but we have a valid id_token_hint with a client
+            // that we could validate (meaning we extracted userId from it)
+            if ($userId !== null && $id_token_hint !== null) {
+                // We already validated the JWT and extracted the client from it
+                // The post_logout_redirect_uri belongs to this client
+                return new RedirectResponse($post_logout_redirect_uri);
+            }
+            
+            // If client_id is provided, we can also accept it
+            if ($client_id !== null) {
+                $client = $this->clientMapper->findByClientIdentifier($client_id);
+                if ($client !== null) {
+                    // Client exists, accept the post_logout_redirect_uri
                     return new RedirectResponse($post_logout_redirect_uri);
                 }
             }

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -158,7 +158,20 @@ class LogoutController extends ApiController
                     ): Response
     {
         $userId = null;
-        if ($id_token_hint) {
+        
+        // According to OIDC RP-Initiated Logout spec: 
+        // The OP SHOULD NOT rely on the id_token_hint as the only way to identify the logged-in End-User
+        // If the End-User is logged in at the OP, the OP MUST log the End-User out
+        // Therefore, we prioritize the active session over the id_token_hint
+        
+        // First, check if there is an active user session
+        if ($this->userSession !== null && $this->userSession->isLoggedIn()) {
+            $userId = $this->userSession->getUser()->getUID();
+            // Logout user from session
+            $this->userSession->logout();
+            // When session exists, id_token_hint is ignored per spec
+        } else if ($id_token_hint) {
+            // Only evaluate id_token_hint if no active session exists
             // check Token to get user id
             $oidcKey = [
                 'kty' => 'RSA',
@@ -182,11 +195,12 @@ class LogoutController extends ApiController
                 $decodedStdClass = JWT::decode($id_token_hint, JWK::parseKeySet($jwks));
                 $decodedJwt = (array) $decodedStdClass;
             } catch (InvalidArgumentException | DomainException | SignatureInvalidException | BeforeValidException | ExpiredException | UnexpectedValueException $e) {
-                // According to OIDC RP-Initiated Logout spec, the OP SHOULD NOT rely on id_token_hint as the only way
-                // to identify the logged-in user. If the token is invalid, we should still proceed with
-                // session-based logout. Only log a warning and continue.
-                $this->logger->warning('Could not validate id_token_hint: ' . $e->getMessage());
-                $decodedJwt = null;
+                // If we cannot validate the token and there's no session, we cannot proceed
+                $this->logger->error('Could not validate id_token_hint: ' . $e->getMessage());
+                return new JSONResponse([
+                    'error' => 'invalid_jwt',
+                    'error_description' => 'Provided id_token_hint is invalid: ' . $e->getMessage()
+                ], Http::STATUS_UNAUTHORIZED);
             }
 
             if ($decodedJwt != null) {
@@ -219,12 +233,6 @@ class LogoutController extends ApiController
                     ], Http::STATUS_UNAUTHORIZED);
                 }
             }
-        }
-
-        if ($this->userSession !== null && $this->userSession->isLoggedIn()) {
-            $userId = $this->userSession->getUser()->getUID();
-            // Logout user from session
-            $this->userSession->logout();
         }
 
         if ($userId != null) {

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -113,6 +113,22 @@ class LogoutController extends ApiController
     }
 
     /**
+     * Build a logout redirect URL with optional state parameter
+     *
+     * @param string $url The base URL to redirect to
+     * @param string|null $state The state parameter to include in the redirect
+     * @return RedirectResponse
+     */
+    private function buildLogoutRedirect(string $url, ?string $state): RedirectResponse {
+        if ($state !== null && $state !== '') {
+            // Append state parameter to the URL
+            $separator = (str_contains($url, '?') ? '&' : '?');
+            $url .= $separator . 'state=' . urlencode($state);
+        }
+        return new RedirectResponse($url);
+    }
+
+    /**
      * @PublicPage
      * @NoCSRFRequired
      * @UseSession
@@ -130,10 +146,11 @@ class LogoutController extends ApiController
     public function logoutPost(
                     string|null $client_id = null, // Optional
                     string|null $id_token_hint = null, // Recommended to be used
-                    string|null $post_logout_redirect_uri = null // Optional url to be redirected to after logout
+                    string|null $post_logout_redirect_uri = null, // Optional url to be redirected to after logout
+                    string|null $state = null // REQUIRED if post_logout_redirect_uri is present
                     ): Response
     {
-        return $this->logout($client_id, $id_token_hint, $post_logout_redirect_uri);
+        return $this->logout($client_id, $id_token_hint, $post_logout_redirect_uri, $state);
     }
 
     /**
@@ -154,7 +171,8 @@ class LogoutController extends ApiController
     public function logout(
                     string|null $client_id = null, // Optional
                     string|null $id_token_hint = null, // Recommended to be used
-                    string|null $post_logout_redirect_uri = null // Optional url to be redirected to after logout
+                    string|null $post_logout_redirect_uri = null, // Optional url to be redirected to after logout
+                    string|null $state = null // REQUIRED if post_logout_redirect_uri is present
                     ): Response
     {
         $userId = null;
@@ -271,14 +289,14 @@ class LogoutController extends ApiController
             $logoutRedirectUris = $this->logoutRedirectUriMapper->getAll();
             foreach ($logoutRedirectUris as $logoutRedirectUri) {
                 if ($post_logout_redirect_uri === $logoutRedirectUri->getRedirectUri()) {
-                    return new RedirectResponse($post_logout_redirect_uri);
+                    return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
                 }
             }
             
             // If we performed a session logout, the request is authenticated
             // and we can trust the post_logout_redirect_uri
             if ($sessionLogout) {
-                return new RedirectResponse($post_logout_redirect_uri);
+                return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
             }
             
             // If not in the table, but we have a valid id_token_hint with a client
@@ -286,7 +304,7 @@ class LogoutController extends ApiController
             if ($userId !== null && $id_token_hint !== null) {
                 // We already validated the JWT and extracted the client from it
                 // The post_logout_redirect_uri belongs to this client
-                return new RedirectResponse($post_logout_redirect_uri);
+                return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
             }
             
             // If client_id is provided, we can also accept it
@@ -294,7 +312,7 @@ class LogoutController extends ApiController
                 $client = $this->clientMapper->findByClientIdentifier($client_id);
                 if ($client !== null) {
                     // Client exists, accept the post_logout_redirect_uri
-                    return new RedirectResponse($post_logout_redirect_uri);
+                    return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
                 }
             }
         }

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -176,6 +176,7 @@ class LogoutController extends ApiController
                     ): Response
     {
         $userId = null;
+        $validatedIdTokenHint = false;
         
         // According to OIDC RP-Initiated Logout spec: 
         // The OP SHOULD NOT rely on the id_token_hint as the only way to identify the logged-in End-User
@@ -188,16 +189,12 @@ class LogoutController extends ApiController
             // Logout user from Nextcloud session
             // This terminates the current session and invalidates the session cookies
             $this->userSession->logout();
-            // When session exists, id_token_hint is ignored per OIDC spec
-            // Mark that we have a valid session logout
-            $sessionLogout = true;
-        } else {
-            $sessionLogout = false;
         }
         
-        // Only evaluate id_token_hint if no active session exists
-        if (!$sessionLogout && $id_token_hint) {
-            // Only evaluate id_token_hint if no active session exists
+        // Validate an ID Token Hint even if there is an active session.  A hint is
+        // optional for logging out, but it is required to authenticate a
+        // post_logout_redirect_uri.
+        if ($id_token_hint) {
             // First, validate the JWT header and basic claims before decoding
             
             // Check if we can decode the header
@@ -302,6 +299,8 @@ class LogoutController extends ApiController
                         'error_description' => 'Provided client_id does not match to the one issued the JWT.'
                     ], Http::STATUS_UNAUTHORIZED);
                 }
+
+                $validatedIdTokenHint = true;
             }
         }
 
@@ -321,41 +320,14 @@ class LogoutController extends ApiController
                         ]
         );
 
-        if (!empty($post_logout_redirect_uri)) {
-            // According to OIDC RP-Initiated Logout spec, the OP should accept
-            // post_logout_redirect_uri if it belongs to the client
-            // We validate this in several ways:
-            // 1. Check if URI is in the pre-registered LogoutRedirectUri table
-            // 2. If we had a valid session logout, the client is authenticated, accept the URI
-            // 3. Check if we have a valid id_token_hint with matching client
-            // 4. Check if client_id is provided and matches a registered client
-            
+        if (!empty($post_logout_redirect_uri) && $validatedIdTokenHint) {
+            // RP-Initiated Logout permits a post-logout redirect only if the RP
+            // is identified by a valid ID Token Hint and the URI is registered.
+            // Matching must be exact; accepting a URI based on an active OP
+            // session or a client_id alone would allow open redirects.
             $logoutRedirectUris = $this->logoutRedirectUriMapper->getAll();
             foreach ($logoutRedirectUris as $logoutRedirectUri) {
                 if ($post_logout_redirect_uri === $logoutRedirectUri->getRedirectUri()) {
-                    return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
-                }
-            }
-            
-            // If we performed a session logout, the request is authenticated
-            // and we can trust the post_logout_redirect_uri
-            if ($sessionLogout) {
-                return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
-            }
-            
-            // If not in the table, but we have a valid id_token_hint with a client
-            // that we could validate (meaning we extracted userId from it)
-            if ($userId !== null && $id_token_hint !== null) {
-                // We already validated the JWT and extracted the client from it
-                // The post_logout_redirect_uri belongs to this client
-                return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
-            }
-            
-            // If client_id is provided, we can also accept it
-            if ($client_id !== null) {
-                $client = $this->clientMapper->findByClientIdentifier($client_id);
-                if ($client !== null) {
-                    // Client exists, accept the post_logout_redirect_uri
                     return $this->buildLogoutRedirect($post_logout_redirect_uri, $state);
                 }
             }

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -198,13 +198,47 @@ class LogoutController extends ApiController
         // Only evaluate id_token_hint if no active session exists
         if (!$sessionLogout && $id_token_hint) {
             // Only evaluate id_token_hint if no active session exists
+            // First, validate the JWT header and basic claims before decoding
+            
+            // Check if we can decode the header
+            $header = null;
+            try {
+                $header = JWT::urlsafeB64Decode(explode('.', $id_token_hint)[0]);
+                $headerData = json_decode($header, true);
+            } catch (\Exception $e) {
+                $this->logger->error('Could not decode id_token_hint header: ' . $e->getMessage());
+                return new JSONResponse([
+                    'error' => 'invalid_jwt',
+                    'error_description' => 'Provided id_token_hint has invalid format'
+                ], Http::STATUS_UNAUTHORIZED);
+            }
+            
+            // Validate algorithm - must be RS256
+            if (isset($headerData['alg']) && $headerData['alg'] !== 'RS256') {
+                $this->logger->error('id_token_hint uses unsupported algorithm: ' . ($headerData['alg'] ?? 'unknown'));
+                return new JSONResponse([
+                    'error' => 'invalid_jwt',
+                    'error_description' => 'id_token_hint must use RS256 algorithm'
+                ], Http::STATUS_UNAUTHORIZED);
+            }
+            
+            // Validate kid if present in header
+            $ourKid = $this->appConfig->getAppValueString('kid');
+            if (!empty($ourKid) && isset($headerData['kid']) && $headerData['kid'] !== $ourKid) {
+                $this->logger->error('id_token_hint has invalid kid: ' . ($headerData['kid'] ?? 'unknown'));
+                return new JSONResponse([
+                    'error' => 'invalid_jwt',
+                    'error_description' => 'id_token_hint has invalid kid'
+                ], Http::STATUS_UNAUTHORIZED);
+            }
+            
             // check Token to get user id
             $oidcKey = [
                 'kty' => 'RSA',
                 'use' => 'sig',
                 'key_ops' => [ 'verify' ],
                 'alg' => 'RS256',
-                'kid' => $this->appConfig->getAppValueString('kid'),
+                'kid' => $ourKid,
                 'n' => $this->appConfig->getAppValueString('public_key_n'),
                 'e' => $this->appConfig->getAppValueString('public_key_e'),
             ];
@@ -226,6 +260,16 @@ class LogoutController extends ApiController
                 return new JSONResponse([
                     'error' => 'invalid_jwt',
                     'error_description' => 'Provided id_token_hint is invalid: ' . $e->getMessage()
+                ], Http::STATUS_UNAUTHORIZED);
+            }
+            
+            // Validate issuer
+            $ourIssuer = $this->urlGenerator->getAbsoluteURL('/');
+            if (isset($decodedJwt['iss']) && $decodedJwt['iss'] !== $ourIssuer) {
+                $this->logger->error('id_token_hint has invalid issuer: ' . ($decodedJwt['iss'] ?? 'unknown'));
+                return new JSONResponse([
+                    'error' => 'invalid_jwt',
+                    'error_description' => 'id_token_hint has invalid issuer'
                 ], Http::STATUS_UNAUTHORIZED);
             }
 

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -167,9 +167,10 @@ class LogoutController extends ApiController
         // First, check if there is an active user session
         if ($this->userSession !== null && $this->userSession->isLoggedIn()) {
             $userId = $this->userSession->getUser()->getUID();
-            // Logout user from session
+            // Logout user from Nextcloud session
+            // This terminates the current session and invalidates the session cookies
             $this->userSession->logout();
-            // When session exists, id_token_hint is ignored per spec
+            // When session exists, id_token_hint is ignored per OIDC spec
             // Mark that we have a valid session logout
             $sessionLogout = true;
         } else {
@@ -220,7 +221,7 @@ class LogoutController extends ApiController
                     ], Http::STATUS_UNAUTHORIZED);
                 }
                 $this->logger->notice('JWT token for uid ' . $uid . ' received.');
-                // create user session for user with id perform login without pw
+                // Validate that the user exists in Nextcloud
                 $user = $this->userManager->get($uid);
                 if (null === $user) {
                     $this->logger->error('Provided user in JWT is unknown.');
@@ -243,9 +244,13 @@ class LogoutController extends ApiController
         }
 
         if ($userId != null) {
+            // Revoke all access tokens for the user to prevent further API access
+            // Note: This does NOT log the user out from other Nextcloud sessions
+            // If the user has multiple sessions, they will remain logged in to Nextcloud
+            // but will not have valid OIDC tokens anymore
             $this->accessTokenMapper->deleteByUserId($userId);
 
-            $this->logger->debug('Logout for user ' . $userId . ' performed.');
+            $this->logger->debug('OIDC tokens revoked for user ' . $userId . '.');
         }
 
         $defaultLogoutRedirectUrl = $this->urlGenerator->linkToRoute(

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -261,7 +261,10 @@ class LogoutController extends ApiController
             }
             
             // Validate issuer
-            $ourIssuer = $this->urlGenerator->getAbsoluteURL('/');
+            $ourIssuer = $this->request->getServerProtocol()
+                . '://'
+                . $this->request->getServerHost()
+                . $this->urlGenerator->getWebroot();
             if (isset($decodedJwt['iss']) && $decodedJwt['iss'] !== $ourIssuer) {
                 $this->logger->error('id_token_hint has invalid issuer: ' . ($decodedJwt['iss'] ?? 'unknown'));
                 return new JSONResponse([

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -119,7 +119,32 @@ class LogoutController extends ApiController
      * @BruteForceProtection(action=oidc_logout)
      *
      * @param string $client_id
-     * @param string $refresh_token
+     * @param string $id_token_hint
+     * @param string $post_logout_redirect_uri
+     * @return Response
+     */
+    #[BruteForceProtection(action: 'oidc_logout')]
+    #[NoCSRFRequired]
+    #[UseSession]
+    #[PublicPage]
+    public function logoutPost(
+                    string|null $client_id = null, // Optional
+                    string|null $id_token_hint = null, // Recommended to be used
+                    string|null $post_logout_redirect_uri = null // Optional url to be redirected to after logout
+                    ): Response
+    {
+        return $this->logout($client_id, $id_token_hint, $post_logout_redirect_uri);
+    }
+
+    /**
+     * @PublicPage
+     * @NoCSRFRequired
+     * @UseSession
+     * @BruteForceProtection(action=oidc_logout)
+     *
+     * @param string $client_id
+     * @param string $id_token_hint
+     * @param string $post_logout_redirect_uri
      * @return Response
      */
     #[BruteForceProtection(action: 'oidc_logout')]

--- a/lib/Controller/LogoutController.php
+++ b/lib/Controller/LogoutController.php
@@ -181,55 +181,12 @@ class LogoutController extends ApiController
             try {
                 $decodedStdClass = JWT::decode($id_token_hint, JWK::parseKeySet($jwks));
                 $decodedJwt = (array) $decodedStdClass;
-            } catch (InvalidArgumentException $e) {
-                // provided key/key-array is empty or malformed.
-                $this->logger->error('Provided key/key-array is empty or malformed.');
-                return new JSONResponse([
-                    'error' => 'invalid_jwt',
-                    'error_description' => 'Provided key/key-array is empty or malformed.'
-                ], Http::STATUS_UNAUTHORIZED);
-            } catch (DomainException $e) {
-                // provided algorithm is unsupported OR
-                // provided key is invalid OR
-                // unknown error thrown in openSSL or libsodium OR
-                // libsodium is required but not available.
-                $this->logger->error('Provided algorithm is unsupported OR provided key is invalid OR unknown error thrown in openSSL or libsodium OR libsodium is required but not available.');
-                return new JSONResponse([
-                    'error' => 'invalid_jwt',
-                    'error_description' => 'Provided algorithm is unsupported OR provided key is invalid OR unknown error thrown in openSSL or libsodium OR libsodium is required but not available.'
-                ], Http::STATUS_UNAUTHORIZED);
-            } catch (SignatureInvalidException $e) {
-                // provided JWT signature verification failed.
-                $this->logger->error('Provided JWT signature verification failed.');
-                return new JSONResponse([
-                    'error' => 'invalid_jwt',
-                    'error_description' => 'Provided JWT signature verification failed.'
-                ], Http::STATUS_UNAUTHORIZED);
-            } catch (BeforeValidException $e) {
-                // provided JWT is trying to be used before "nbf" claim OR
-                // provided JWT is trying to be used before "iat" claim.
-                $this->logger->error('Provided JWT is trying to be used before "nbf" claim OR provided JWT is trying to be used before "iat" claim.');
-                return new JSONResponse([
-                    'error' => 'invalid_jwt',
-                    'error_description' => 'Provided JWT is trying to be used before "nbf" claim OR provided JWT is trying to be used before "iat" claim.'
-                ], Http::STATUS_UNAUTHORIZED);
-            } catch (ExpiredException $e) {
-                // provided JWT is trying to be used after "exp" claim.
-                // $this->logger->error('Provided JWT is trying to be used after "exp" claim.');
-                // return new JSONResponse([
-                //   'error' => 'invalid_jwt',
-                //   'error_description' => 'Provided JWT is trying to be used after "exp" claim.'
-                // ], Http::STATUS_UNAUTHORIZED);
-            } catch (UnexpectedValueException $e) {
-                // provided JWT is malformed OR
-                // provided JWT is missing an algorithm / using an unsupported algorithm OR
-                // provided JWT algorithm does not match provided key OR
-                // provided key ID in key/key-array is empty or invalid.
-                $this->logger->error('Provided JWT is malformed OR provided JWT is missing an algorithm / using an unsupported algorithm OR provided JWT algorithm does not match provided key OR provided key ID in key/key-array is empty or invalid.');
-                return new JSONResponse([
-                    'error' => 'invalid_jwt',
-                    'error_description' => 'Provided JWT is malformed OR provided JWT is missing an algorithm / using an unsupported algorithm OR provided JWT algorithm does not match provided key OR provided key ID in key/key-array is empty or invalid.'
-                ], Http::STATUS_UNAUTHORIZED);
+            } catch (InvalidArgumentException | DomainException | SignatureInvalidException | BeforeValidException | ExpiredException | UnexpectedValueException $e) {
+                // According to OIDC RP-Initiated Logout spec, the OP SHOULD NOT rely on id_token_hint as the only way
+                // to identify the logged-in user. If the token is invalid, we should still proceed with
+                // session-based logout. Only log a warning and continue.
+                $this->logger->warning('Could not validate id_token_hint: ' . $e->getMessage());
+                $decodedJwt = null;
             }
 
             if ($decodedJwt != null) {
@@ -241,7 +198,7 @@ class LogoutController extends ApiController
                         'error_description' => 'Provided JWT does not contain a subject.'
                     ], Http::STATUS_UNAUTHORIZED);
                 }
-                $this->logger->notice('JWT token for uid ' . $uid . ' received.' );
+                $this->logger->notice('JWT token for uid ' . $uid . ' received.');
                 // create user session for user with id perform login without pw
                 $user = $this->userManager->get($uid);
                 if (null === $user) {
@@ -285,7 +242,7 @@ class LogoutController extends ApiController
         if (!empty($post_logout_redirect_uri)) {
             $logoutRedirectUris = $this->logoutRedirectUriMapper->getAll();
             foreach ($logoutRedirectUris as $logoutRedirectUri) {
-                if (str_starts_with($post_logout_redirect_uri, $logoutRedirectUri->getRedirectUri())) {
+                if ($post_logout_redirect_uri === $logoutRedirectUri->getRedirectUri()) {
                     return new RedirectResponse($post_logout_redirect_uri);
                 }
             }

--- a/lib/Db/LogoutRedirectUriMapper.php
+++ b/lib/Db/LogoutRedirectUriMapper.php
@@ -117,4 +117,16 @@ class LogoutRedirectUriMapper extends QBMapper {
             ->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
         $qb->executeStatement();
     }
+
+    /**
+     * Delete logout redirect URIs by their exact URI.
+     */
+    public function deleteByRedirectUri(string $redirectUri): bool {
+        $qb = $this->db->getQueryBuilder();
+        $qb
+            ->delete($this->tableName)
+            ->where($qb->expr()->eq('redirect_uri', $qb->createNamedParameter($redirectUri)));
+
+        return $qb->executeStatement() > 0;
+    }
 }

--- a/tests/Unit/Command/LogoutRedirectUris/OIDCCreateTest.php
+++ b/tests/Unit/Command/LogoutRedirectUris/OIDCCreateTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OIDCIdentityProvider\Tests\Unit\Command\LogoutRedirectUris;
+
+use OCA\OIDCIdentityProvider\AppInfo\Application;
+use OCA\OIDCIdentityProvider\Command\LogoutRedirectUris\OIDCCreate;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUri;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUriMapper;
+use OCA\OIDCIdentityProvider\Service\RedirectUriService;
+use OCP\AppFramework\Services\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class OIDCCreateTest extends TestCase {
+    private LogoutRedirectUriMapper $mapper;
+    private RedirectUriService $redirectUriService;
+    private OIDCCreate $command;
+
+    protected function setUp(): void {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getAppValueString')->with(
+            Application::APP_CONFIG_ALLOW_SUBDOMAIN_WILDCARDS,
+            Application::DEFAULT_ALLOW_SUBDOMAIN_WILDCARDS,
+        )->willReturn(Application::DEFAULT_ALLOW_SUBDOMAIN_WILDCARDS);
+        $this->mapper = $this->createMock(LogoutRedirectUriMapper::class);
+        $this->redirectUriService = $this->createMock(RedirectUriService::class);
+        $this->command = new OIDCCreate($appConfig, $this->mapper, $this->redirectUriService);
+    }
+
+    public function testExecuteCreatesValidatedUri(): void {
+        $uri = 'https://rp.example/logout';
+        $this->redirectUriService->expects($this->once())->method('isValidRedirectUri')->with($uri, false)->willReturn(true);
+        $this->mapper->expects($this->once())->method('insert')->willReturnCallback(static fn (LogoutRedirectUri $entity) => $entity);
+
+        $tester = new CommandTester($this->command);
+        $status = $tester->execute(['redirect_uri' => $uri]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertStringContainsString($uri, $tester->getDisplay());
+    }
+
+    public function testExecuteRejectsInvalidUri(): void {
+        $this->redirectUriService->method('isValidRedirectUri')->willReturn(false);
+        $this->mapper->expects($this->never())->method('insert');
+
+        $tester = new CommandTester($this->command);
+        $status = $tester->execute(['redirect_uri' => 'invalid']);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('not valid', $tester->getDisplay());
+    }
+
+    public function testConfigure(): void {
+        $this->assertSame('oidc:create-logout-redirect-uri', $this->command->getName());
+    }
+}

--- a/tests/Unit/Command/LogoutRedirectUris/OIDCListTest.php
+++ b/tests/Unit/Command/LogoutRedirectUris/OIDCListTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OIDCIdentityProvider\Tests\Unit\Command\LogoutRedirectUris;
+
+use OCA\OIDCIdentityProvider\Command\LogoutRedirectUris\OIDCList;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUri;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUriMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class OIDCListTest extends TestCase {
+    public function testExecuteListsUris(): void {
+        $uri = new LogoutRedirectUri();
+        $uri->setRedirectUri('https://rp.example/logout');
+        $mapper = $this->createMock(LogoutRedirectUriMapper::class);
+        $mapper->method('getAll')->willReturn([$uri]);
+        $tester = new CommandTester(new OIDCList($mapper));
+
+        $status = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertStringContainsString('https://rp.example/logout', $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Command/LogoutRedirectUris/OIDCRemoveTest.php
+++ b/tests/Unit/Command/LogoutRedirectUris/OIDCRemoveTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\OIDCIdentityProvider\Tests\Unit\Command\LogoutRedirectUris;
+
+use OCA\OIDCIdentityProvider\Command\LogoutRedirectUris\OIDCRemove;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUriMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class OIDCRemoveTest extends TestCase {
+    public function testExecuteRemovesUri(): void {
+        $uri = 'https://rp.example/logout';
+        $mapper = $this->createMock(LogoutRedirectUriMapper::class);
+        $mapper->expects($this->once())->method('deleteByRedirectUri')->with($uri)->willReturn(true);
+        $tester = new CommandTester(new OIDCRemove($mapper));
+
+        $status = $tester->execute(['redirect_uri' => $uri]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertStringContainsString('removed', $tester->getDisplay());
+    }
+
+    public function testExecuteReportsMissingUri(): void {
+        $mapper = $this->createMock(LogoutRedirectUriMapper::class);
+        $mapper->method('deleteByRedirectUri')->willReturn(false);
+        $tester = new CommandTester(new OIDCRemove($mapper));
+
+        $status = $tester->execute(['redirect_uri' => 'https://rp.example/missing']);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertStringContainsString('not found', $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Controller/LogoutControllerTest.php
+++ b/tests/Unit/Controller/LogoutControllerTest.php
@@ -63,6 +63,9 @@ class LogoutControllerTest extends TestCase {
         $urlGenerator->method('linkToRoute')
             ->with('core.login.showLoginForm', [])
             ->willReturn('/login');
+        $urlGenerator->method('getAbsoluteURL')
+            ->with('/')
+            ->willReturn('https://nextcloud.local');
         $this->logoutRedirectUriMapper->method('getAll')->willReturn([]);
 
         $this->controller = new LogoutController(

--- a/tests/Unit/Controller/LogoutControllerTest.php
+++ b/tests/Unit/Controller/LogoutControllerTest.php
@@ -7,6 +7,7 @@ use OCA\OIDCIdentityProvider\Controller\LogoutController;
 use OCA\OIDCIdentityProvider\Db\AccessTokenMapper;
 use OCA\OIDCIdentityProvider\Db\ClientMapper;
 use OCA\OIDCIdentityProvider\Db\LogoutRedirectUriMapper;
+use OCA\OIDCIdentityProvider\Db\LogoutRedirectUri;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http;
@@ -66,8 +67,6 @@ class LogoutControllerTest extends TestCase {
         $urlGenerator->method('getAbsoluteURL')
             ->with('/')
             ->willReturn('https://nextcloud.local');
-        $this->logoutRedirectUriMapper->method('getAll')->willReturn([]);
-
         $this->controller = new LogoutController(
             'oidc',
             $request,
@@ -124,6 +123,67 @@ class LogoutControllerTest extends TestCase {
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertEquals(Http::STATUS_UNAUTHORIZED, $result->getStatus());
         $this->assertEquals('invalid_jwt', $result->getData()['error']);
+    }
+
+    public function testLogoutDoesNotRedirectWithoutIdTokenHint(): void {
+        $this->addRegisteredLogoutRedirectUri('https://rp.example/logout');
+
+        $result = $this->controller->logout(null, null, 'https://rp.example/logout');
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/login', $result->getRedirectURL());
+    }
+
+    public function testLogoutRejectsInvalidIdTokenHintEvenWithActiveSession(): void {
+        $this->addRegisteredLogoutRedirectUri('https://rp.example/logout');
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('user1');
+        $this->userSession->method('isLoggedIn')->willReturn(true);
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->userSession->expects($this->once())->method('logout');
+
+        $result = $this->controller->logout(null, 'not-a-jwt', 'https://rp.example/logout');
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertEquals(Http::STATUS_UNAUTHORIZED, $result->getStatus());
+    }
+
+    public function testLogoutOnlyRedirectsToAnExactlyRegisteredUri(): void {
+        $userId = 'user1';
+        $clientId = 'client1';
+        $idTokenHint = $this->createIdTokenHint([
+            'sub' => $userId,
+            'aud' => $clientId,
+        ]);
+        $this->addRegisteredLogoutRedirectUri('https://rp.example/logout');
+        $this->userManager->method('get')->with($userId)->willReturn($this->createMock(IUser::class));
+
+        $result = $this->controller->logout($clientId, $idTokenHint, 'https://rp.example/logout?foo=bar');
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/login', $result->getRedirectURL());
+    }
+
+    public function testLogoutRedirectsWithValidIdTokenHintAndRegisteredUri(): void {
+        $userId = 'user1';
+        $clientId = 'client1';
+        $idTokenHint = $this->createIdTokenHint([
+            'sub' => $userId,
+            'aud' => $clientId,
+        ]);
+        $this->addRegisteredLogoutRedirectUri('https://rp.example/logout');
+        $this->userManager->method('get')->with($userId)->willReturn($this->createMock(IUser::class));
+
+        $result = $this->controller->logout($clientId, $idTokenHint, 'https://rp.example/logout', 'state value');
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('https://rp.example/logout?state=state+value', $result->getRedirectURL());
+    }
+
+    private function addRegisteredLogoutRedirectUri(string $uri): void {
+        $logoutRedirectUri = new LogoutRedirectUri();
+        $logoutRedirectUri->setRedirectUri($uri);
+        $this->logoutRedirectUriMapper->method('getAll')->willReturn([$logoutRedirectUri]);
     }
 
     /**

--- a/tests/Unit/Controller/LogoutControllerTest.php
+++ b/tests/Unit/Controller/LogoutControllerTest.php
@@ -66,7 +66,10 @@ class LogoutControllerTest extends TestCase {
             ->willReturn('/login');
         $urlGenerator->method('getAbsoluteURL')
             ->with('/')
-            ->willReturn('https://nextcloud.local');
+            ->willReturn('https://internal.nextcloud.local');
+        $urlGenerator->method('getWebroot')->willReturn('');
+        $request->method('getServerProtocol')->willReturn('https');
+        $request->method('getServerHost')->willReturn('nextcloud.local');
         $this->controller = new LogoutController(
             'oidc',
             $request,


### PR DESCRIPTION
- Add OIDC conformance tests for RP-initiated logout
- Support modifying allowed logout redirect uris via cli
- Support state attribute during logout flow
- Tighten validation for allowed logout redirect uris and id_token_hint JWTs
- Modify the behavior to terminate an existing user session (identified e.g. by cookies), even if a id_token_hint could not be validated correctly