### PR TITLE
fix(token): honor refresh_expire_time never instead of casting it to 0

### DIFF
--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -208,8 +208,8 @@ class OIDCApiController extends ApiController {
         string|null $client_secret = null,
         string|null $code_verifier = null): JSONResponse
     {
-		$expireTime = (int)$this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_EXPIRE_TIME, '0');
-		$refreshExpireTime = $this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_REFRESH_EXPIRE_TIME, Application::DEFAULT_REFRESH_EXPIRE_TIME);
+        $expireTime = (int)$this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_EXPIRE_TIME, '0');
+        $refreshExpireTime = $this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_REFRESH_EXPIRE_TIME, Application::DEFAULT_REFRESH_EXPIRE_TIME);
 		// We only handle two types
         if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {
             $this->logger->info('Invalid grant_type provided. Must be authorization_code or refresh_token for client id ' . $client_id . '.');

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -210,7 +210,7 @@ class OIDCApiController extends ApiController {
     {
         $expireTime = (int)$this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_EXPIRE_TIME, '0');
         $refreshExpireTime = $this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_REFRESH_EXPIRE_TIME, Application::DEFAULT_REFRESH_EXPIRE_TIME);
-		// We only handle two types
+        // We only handle two types
         if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {
             $this->logger->info('Invalid grant_type provided. Must be authorization_code or refresh_token for client id ' . $client_id . '.');
             return new JSONResponse([

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -208,7 +208,7 @@ class OIDCApiController extends ApiController {
         string|null $client_secret = null,
         string|null $code_verifier = null): JSONResponse
     {
-        $expireTime = (int)$this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_EXPIRE_TIME, '0');
+        $expireTime = $this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_EXPIRE_TIME, '0');
         $refreshExpireTime = (int)$this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_REFRESH_EXPIRE_TIME, Application::DEFAULT_REFRESH_EXPIRE_TIME);
         // We only handle two types
         if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -208,9 +208,9 @@ class OIDCApiController extends ApiController {
         string|null $client_secret = null,
         string|null $code_verifier = null): JSONResponse
     {
-        $expireTime = $this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_EXPIRE_TIME, '0');
-        $refreshExpireTime = (int)$this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_REFRESH_EXPIRE_TIME, Application::DEFAULT_REFRESH_EXPIRE_TIME);
-        // We only handle two types
+		$expireTime = (int)$this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_EXPIRE_TIME, '0');
+		$refreshExpireTime = $this->appConfig->getAppValueString(Application::APP_CONFIG_DEFAULT_REFRESH_EXPIRE_TIME, Application::DEFAULT_REFRESH_EXPIRE_TIME);
+		// We only handle two types
         if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {
             $this->logger->info('Invalid grant_type provided. Must be authorization_code or refresh_token for client id ' . $client_id . '.');
             return new JSONResponse([


### PR DESCRIPTION
refresh_expire_time is cast to int, so (int)"never" becomes 0 before either `!== 'never'` guard.

we end up with now > refreshed + 0 which is true for every request after issuance. all refresh grants fail with invalid_grant/Refresh token is expired. and the access token row is deleted.

lines 368 and 453 already cast when a number is needed.

this also fixes refresh_expires_in being emitted as 0 rather than omitted.