### PR TITLE
Fix client secret basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Several global OIDC app settings can be changed with the Nextcloud `occ config:a
 | `group_claim_type` | Controls whether the `groups` claim contains internal group IDs or display names. Supported values are `gid` and `displayname`. | `occ config:app:set oidc group_claim_type --value "displayname"` |
 | `role_claim_type` | Controls whether the `roles` claim contains internal group IDs or display names. Supported values are `gid`, `displayname`, and `null`; `null` follows `group_claim_type`. | `occ config:app:set oidc role_claim_type --value "gid"` |
 | `allow_subdomain_wildcards` | Enables or disables subdomain wildcards in redirect URIs, for example `https://*.example.com/callback`. Supported values are `true` and `false`. | `occ config:app:set oidc allow_subdomain_wildcards --value "true"` |
+| `disable_auth_client_secret_basic` | Enables or disables support for the client_secret_basic authentication method. Supported values are `true` and `false`. | `occ config:app:set oidc disable_auth_client_secret_basic --value true` |
 
 ## JWT Access Tokens (RFC9068)
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ class Application extends App implements IBootstrap
     public const DEFAULT_PROVIDE_REFRESH_TOKEN_ALWAYS = 'false';
     public const DEFAULT_ALLOW_SUBDOMAIN_WILDCARDS = 'false';
 
+    public const DEFAULT_DISABLE_AUTH_CLIENT_SECRET_BASIC = false;
     public const DEFAULT_ALWAYS_INCLUDE_SCOPE_CLAIMS = false;
 
     public const GROUP_CLAIM_TYPE_GID = 'gid';
@@ -54,6 +55,7 @@ class Application extends App implements IBootstrap
     public const APP_CONFIG_PROVIDE_REFRESH_TOKEN_ALWAYS = 'provide_refresh_token_always';
     public const APP_CONFIG_ALLOW_SUBDOMAIN_WILDCARDS = 'allow_subdomain_wildcards';
     public const APP_CONFIG_ALWAYS_INCLUDE_SCOPE_CLAIMS = 'always_include_scope_claims';
+    public const APP_CONFIG_DISABLE_AUTH_CLIENT_SECRET_BASIC = 'disable_auth_client_secret_basic';
 
     private $backend;
 

--- a/lib/BasicAuthBackend.php
+++ b/lib/BasicAuthBackend.php
@@ -196,23 +196,7 @@ class BasicAuthBackend extends \OC\User\Backend {
      * @return boolean
      */
     public function userExists($uid) {
-        if (strlen($uid) < 32 || strlen($uid) > 64) {
-            return false;
-        }
-
-        try {
-            $client = $this->clientMapper->getByIdentifier($uid);
-        } catch (ClientNotFoundException $e) {
-            $this->logger->notice('OIDCIdentityProvider BasicAuthBackend: Could not find client. Client id was ' . $uid . '.');
-            return false;
-        }
-
-        if ($client->getClientIdentifier() !== $uid) {
-            $this->logger->notice('OIDCIdentityProvider BasicAuthBackend: Client not found. Client id was ' . $uid . '.');
-            return false;
-        }
-
-        return true;
+        return false;
     }
 
     /**

--- a/lib/BasicAuthBackend.php
+++ b/lib/BasicAuthBackend.php
@@ -83,11 +83,7 @@ class BasicAuthBackend extends \OC\User\Backend {
      *
      * Check if the password is correct without logging in the user
      */
-    public function checkPassword($uid, $password) {
-        if (strlen($uid) < 32 || strlen($uid) > 64 || strlen($password) < 32 || strlen($password) > 64) {
-            return false;
-        }
-
+    public function checkPassword($loginName, $password) {
         // Limit access to token and introspection endpoints only
         $requestUri = $this->request->getRequestUri();
         $requestUri = strtok($requestUri,"?");
@@ -97,28 +93,41 @@ class BasicAuthBackend extends \OC\User\Backend {
             return false;
         }
 
+        // RFC 6749 client_secret_basic encoding
+        $clientId = urldecode($loginName);
+        $clientSecret = urldecode($password);
+
+        if (
+            strlen($clientId) < 32 ||
+            strlen($clientId) > 64 ||
+            strlen($clientSecret) < 32 ||
+            strlen($clientSecret) > 64
+        ) {
+            return false;
+        }
+
         try {
-            $client = $this->clientMapper->getByIdentifier($uid);
+            $client = $this->clientMapper->getByIdentifier($clientId);
         } catch (ClientNotFoundException $e) {
-            $this->logger->notice('OIDCIdentityProvider BasicAuthBackend: Could not find client. Client id was ' . $uid . '.');
+            $this->logger->notice('OIDCIdentityProvider BasicAuthBackend: Could not find client. Client id was ' . $clientId . '.');
             return false;
         }
 
         if ($client->getType() === 'public') {
             // Only the client id must match for a public client. Else we don't provide an access token!
-            if ($client->getClientIdentifier() !== $uid) {
-                $this->logger->notice('OIDCIdentityProvider BasicAuthBackend: Client not found. Client id was ' . $uid . '.');
+            if ($client->getClientIdentifier() !== $clientId) {
+                $this->logger->notice('OIDCIdentityProvider BasicAuthBackend: Client not found. Client id was ' . $clientId . '.');
                 return false;
             }
         } else {
             // The client id and secret must match. Else we don't provide an access token!
-            if ($client->getClientIdentifier() !== $uid || $client->getSecret() !== $password) {
-                $this->logger->error('OIDCIdentityProvider BasicAuthBackend: Client authentication failed. Client id was ' . $uid . '.');
+            if ($client->getClientIdentifier() !== $clientId || $client->getSecret() !== $clientSecret) {
+                $this->logger->error('OIDCIdentityProvider BasicAuthBackend: Client authentication failed. Client id was ' . $clientId . '.');
                 return false;
             }
         }
 
-        return true;
+        return $clientId;
     }
 
     /**

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -253,13 +253,13 @@ class OIDCApiController extends ApiController {
             return $this->invalidGrantResponse('Could not find access token for code or refresh_token.');
         }
 
-        if (!isset($client_id)) {
+        if (!empty($client_id)) {
             $this->logger->debug('No client_id in request. Trying to fetch from Authorization Header.');
-            if (isset($this->request->server['PHP_AUTH_USER'])) {
-                $client_id = $this->request->server['PHP_AUTH_USER'];
-                $client_secret = $this->request->server['PHP_AUTH_PW'] ?? null;
+            if (empty($this->request->server['PHP_AUTH_USER'])) {
+                $client_id = urldecode($this->request->server['PHP_AUTH_USER']);
+                $client_secret = urldecode($this->request->server['PHP_AUTH_PW'] ?? '');
             }
-            if (!isset($client_id)) {
+            if (!empty($client_id)) {
                 $this->logger->debug('No client_id in PHP_AUTH_USER superglobal. Trying to fetch from Authorization Header directly.');
                 $authHeader = $this->getAuthorizationHeader();
                 if ($authHeader && stripos($authHeader, 'Basic ') === 0) {
@@ -267,6 +267,8 @@ class OIDCApiController extends ApiController {
                     $decoded = base64_decode($base64, true);
                     if ($decoded !== false && strpos($decoded, ':') !== false) {
                         list($client_id, $client_secret) = explode(':', $decoded, 2);
+                        $client_id = urldecode($client_id);
+                        $client_secret = urldecode($client_secret);
                     }
                 } else {
                     $this->logger->debug('No Authorization Header with client_id found.');

--- a/lib/Controller/OIDCApiController.php
+++ b/lib/Controller/OIDCApiController.php
@@ -253,13 +253,13 @@ class OIDCApiController extends ApiController {
             return $this->invalidGrantResponse('Could not find access token for code or refresh_token.');
         }
 
-        if (!empty($client_id)) {
+        if (!isset($client_id)) {
             $this->logger->debug('No client_id in request. Trying to fetch from Authorization Header.');
-            if (empty($this->request->server['PHP_AUTH_USER'])) {
+            if (isset($this->request->server['PHP_AUTH_USER'])) {
                 $client_id = urldecode($this->request->server['PHP_AUTH_USER']);
                 $client_secret = urldecode($this->request->server['PHP_AUTH_PW'] ?? '');
             }
-            if (!empty($client_id)) {
+            if (!isset($client_id)) {
                 $this->logger->debug('No client_id in PHP_AUTH_USER superglobal. Trying to fetch from Authorization Header directly.');
                 $authHeader = $this->getAuthorizationHeader();
                 if ($authHeader && stripos($authHeader, 'Basic ') === 0) {

--- a/lib/Util/DiscoveryGenerator.php
+++ b/lib/Util/DiscoveryGenerator.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\AppFramework\Http\Response;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\AppFramework\Services\IAppConfig;
@@ -31,19 +32,23 @@ class DiscoveryGenerator
     private $logger;
     /** @var ClientMapper */
     private $clientMapper;
+    /** @var IConfig */
+    private $config;
 
     public function __construct(
                     ITimeFactory $time,
                     IURLGenerator $urlGenerator,
                     IAppConfig $appConfig,
                     LoggerInterface $logger,
-                    ClientMapper $clientMapper
+                    ClientMapper $clientMapper,
+                    IConfig $config
     ) {
         $this->time = $time;
         $this->urlGenerator = $urlGenerator;
         $this->appConfig = $appConfig;
         $this->logger = $logger;
         $this->clientMapper = $clientMapper;
+        $this->config = $config;
     }
 
     /**
@@ -142,13 +147,17 @@ class DiscoveryGenerator
         // $userinfoSigningAlgValuesSupported = [
         //     'none',
         // ];
+        $tokenAuthEnforced = $this->config->getSystemValueBool(
+            'token_auth_enforced',
+            false
+        );
         $tokenEndpointAuthMethodsSupported = [
             'client_secret_post',
             'client_secret_basic',
             // 'client_secret_jwt',
             // 'private_key_jwt',
         ];
-        if ($this->appConfig->getAppValueBool(Application::APP_CONFIG_DISABLE_AUTH_CLIENT_SECRET_BASIC)) {
+        if ($tokenAuthEnforced || $this->appConfig->getAppValueBool(Application::APP_CONFIG_DISABLE_AUTH_CLIENT_SECRET_BASIC, false)) {
             $tokenEndpointAuthMethodsSupported = ['client_secret_post'];
         }
         $displayValuesSupported = [
@@ -240,6 +249,9 @@ class DiscoveryGenerator
             'client_secret_post',
             'client_secret_basic'
         ];
+        if ($tokenAuthEnforced || $this->appConfig->getAppValueBool(Application::APP_CONFIG_DISABLE_AUTH_CLIENT_SECRET_BASIC, false)) {
+            $discoveryPayload['introspection_endpoint_auth_methods_supported'] = ['client_secret_post'];
+        }
 
         // Add PKCE support to discovery endpoint
         $discoveryPayload['code_challenge_methods_supported'] = ['S256', 'plain'];

--- a/lib/Util/DiscoveryGenerator.php
+++ b/lib/Util/DiscoveryGenerator.php
@@ -148,6 +148,9 @@ class DiscoveryGenerator
             // 'client_secret_jwt',
             // 'private_key_jwt',
         ];
+        if ($this->appConfig->getAppValueBool(Application::APP_CONFIG_DISABLE_AUTH_CLIENT_SECRET_BASIC)) {
+            $tokenEndpointAuthMethodsSupported = ['client_secret_post'];
+        }
         $displayValuesSupported = [
             'page',
             // 'popup',

--- a/tests/Unit/BasicAuthBackendTest.php
+++ b/tests/Unit/BasicAuthBackendTest.php
@@ -91,17 +91,24 @@ class BasicAuthBackendTest extends TestCase {
     // --- checkPassword: length validation ---
 
     public function testCheckPasswordRejectsTooShort() {
-        $this->assertFalse($this->backend->checkPassword('short', 'short'));
+        $clientId = 'short';
+        $clientSecret = 'short';
+        $this->setupValidClient($clientId, $clientSecret);
+        $this->assertFalse($this->backend->checkPassword($clientId, $clientSecret));
     }
 
     public function testCheckPasswordRejectsTooLong() {
-        $uid = str_repeat('a', 65);
-        $secret = str_repeat('b', 65);
-        $this->assertFalse($this->backend->checkPassword($uid, $secret));
+        $clientId = str_repeat('a', 65);
+        $clientSecret = str_repeat('b', 65);
+        $this->setupValidClient($clientId, $clientSecret);
+        $this->assertFalse($this->backend->checkPassword($clientId, $clientSecret));
     }
 
     public function testCheckPasswordRejectsEmpty() {
-        $this->assertFalse($this->backend->checkPassword('', ''));
+        $clientId = '';
+        $clientSecret = '';
+        $this->setupValidClient($clientId, $clientSecret);
+        $this->assertFalse($this->backend->checkPassword($clientId, $clientSecret));
     }
 
     // --- checkPassword: accepts valid lengths on token endpoint ---
@@ -122,17 +129,17 @@ class BasicAuthBackendTest extends TestCase {
 
     public function testCheckPasswordAccepts64CharCredentials() {
         $this->setupValidClient($this->uid64, $this->secret64);
-        $this->assertTrue($this->backend->checkPassword($this->uid64, $this->secret64));
+        $this->assertNotFalse($this->backend->checkPassword($this->uid64, $this->secret64));
     }
 
     public function testCheckPasswordAccepts48CharCredentials() {
         $this->setupValidClient($this->uid48, $this->secret48);
-        $this->assertTrue($this->backend->checkPassword($this->uid48, $this->secret48));
+        $this->assertNotFalse($this->backend->checkPassword($this->uid48, $this->secret48));
     }
 
     public function testCheckPasswordAccepts32CharCredentials() {
         $this->setupValidClient($this->uid32, $this->secret32);
-        $this->assertTrue($this->backend->checkPassword($this->uid32, $this->secret32));
+        $this->assertNotFalse($this->backend->checkPassword($this->uid32, $this->secret32));
     }
 
     // --- checkPassword: endpoint restriction ---
@@ -157,7 +164,7 @@ class BasicAuthBackendTest extends TestCase {
             ->with($this->uid64)
             ->willReturn($client);
 
-        $this->assertTrue($this->backend->checkPassword($this->uid64, $this->secret64));
+        $this->assertNotFalse($this->backend->checkPassword($this->uid64, $this->secret64));
     }
 
     // --- checkPassword: wrong secret ---
@@ -201,42 +208,18 @@ class BasicAuthBackendTest extends TestCase {
     }
 
     public function testUserExistsAccepts64Char() {
-        $client = new Client();
-        $client->setClientIdentifier($this->uid64);
-
-        $this->clientMapper->method('getByIdentifier')
-            ->with($this->uid64)
-            ->willReturn($client);
-
-        $this->assertTrue($this->backend->userExists($this->uid64));
+        $this->assertFalse($this->backend->userExists($this->uid64));
     }
 
     public function testUserExistsAccepts48Char() {
-        $client = new Client();
-        $client->setClientIdentifier($this->uid48);
-
-        $this->clientMapper->method('getByIdentifier')
-            ->with($this->uid48)
-            ->willReturn($client);
-
-        $this->assertTrue($this->backend->userExists($this->uid48));
+        $this->assertFalse($this->backend->userExists($this->uid48));
     }
 
     public function testUserExistsAccepts32Char() {
-        $client = new Client();
-        $client->setClientIdentifier($this->uid32);
-
-        $this->clientMapper->method('getByIdentifier')
-            ->with($this->uid32)
-            ->willReturn($client);
-
-        $this->assertTrue($this->backend->userExists($this->uid32));
+        $this->assertFalse($this->backend->userExists($this->uid32));
     }
 
     public function testUserExistsReturnsFalseForUnknownClient() {
-        $this->clientMapper->method('getByIdentifier')
-            ->willThrowException(new ClientNotFoundException());
-
         $this->assertFalse($this->backend->userExists($this->uid64));
     }
 }

--- a/tests/Unit/Controller/DiscoveryControllerTest.php
+++ b/tests/Unit/Controller/DiscoveryControllerTest.php
@@ -67,13 +67,18 @@ class DiscoveryControllerTest extends TestCase {
         $constructor = $reflection->getConstructor();
         $constructor->invoke($this->throttler, $this->time, $this->logger, $this->config, $this->throttlerBackend, $this->bruteforceAllowList);
         
+        $this->config->method('getSystemValueBool')
+            ->willReturnCallback(function($key, $default) {
+                return $default;
+            });
         $this->clientMapper = $this->createMock(ClientMapper::class);
         $this->discoveryGenerator = new DiscoveryGenerator(
                                                             $this->time,
                                                             $this->urlGenerator,
                                                             $this->appConfig,
                                                             $this->logger,
-                                                            $this->clientMapper
+                                                            $this->clientMapper,
+                                                            $this->config
         );
 
         $this->controller = new DiscoveryController(

--- a/tests/Unit/Util/DiscoveryGeneratorTest.php
+++ b/tests/Unit/Util/DiscoveryGeneratorTest.php
@@ -5,6 +5,7 @@ namespace OCA\OIDCIdentityProvider\Tests\Unit\Util;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\AppFramework\Http\JSONResponse;
@@ -40,6 +41,9 @@ class DiscoveryGeneratorTest extends TestCase {
     /** @var \PHPUnit\Framework\MockObject\MockObject|IRequest */
     private $request;
 
+    /** @var \PHPUnit\Framework\MockObject\MockObject|IConfig */
+    private $config;
+
     public function setUp(): void {
         $this->time = $this->createMock(ITimeFactory::class);
         $this->urlGenerator = $this->createMock(IURLGenerator::class);
@@ -47,6 +51,11 @@ class DiscoveryGeneratorTest extends TestCase {
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->clientMapper = $this->createMock(ClientMapper::class);
         $this->request = $this->createMock(IRequest::class);
+        $this->config = $this->createMock(IConfig::class);
+        $this->config->method('getSystemValueBool')
+            ->willReturnCallback(function($key, $default) {
+                return $default;
+            });
         
         $this->urlGenerator->method('getWebroot')->willReturn('/');
         $this->urlGenerator->method('linkToRoute')
@@ -68,7 +77,8 @@ class DiscoveryGeneratorTest extends TestCase {
             $this->urlGenerator,
             $this->appConfig,
             $this->logger,
-            $this->clientMapper
+            $this->clientMapper,
+            $this->config
         );
     }
 
@@ -366,5 +376,36 @@ class DiscoveryGeneratorTest extends TestCase {
             ->with('Request to Discovery Endpoint.');
         
         $this->generator->generateDiscovery($this->request);
+    }
+
+    public function testGenerateDiscoveryTokenAuthEnforcedDisablesClientSecretBasic() {
+        $this->config = $this->createMock(IConfig::class);
+        $this->config->method('getSystemValueBool')
+            ->willReturnCallback(function($key, $default) {
+                if ($key === 'token_auth_enforced') {
+                    return true;
+                }
+                return $default;
+            });
+
+        $generator = new DiscoveryGenerator(
+            $this->time,
+            $this->urlGenerator,
+            $this->appConfig,
+            $this->logger,
+            $this->clientMapper,
+            $this->config
+        );
+
+        $result = $generator->generateDiscovery($this->request);
+        $data = $result->getData();
+
+        $tokenMethods = $data['token_endpoint_auth_methods_supported'];
+        $this->assertContains('client_secret_post', $tokenMethods);
+        $this->assertNotContains('client_secret_basic', $tokenMethods);
+
+        $introspectionMethods = $data['introspection_endpoint_auth_methods_supported'];
+        $this->assertContains('client_secret_post', $introspectionMethods);
+        $this->assertNotContains('client_secret_basic', $introspectionMethods);
     }
 }


### PR DESCRIPTION
Improved handling of client_secret_basic authentication. But still this must be implemented using a pseudo user backend since the Nextcloud Core intercepts any requests containing an Authorization header. 
- Improved pseudo user backend concerning integration with Nextcloud Core
- Corrected urldecoding for clientId and clientSecrets
- Allow to disable/enable client_secret_basic authentication in discovery endpoint using occ config:app:set oidc disable_auth_client_secret_basic --value true in case it should be disabled
- client_secret_basic is automatically disabled at discovery endpoint when system value ´token_auth_enforced´ is enabled. Since in this case the pseudo user backend will not be called by the Nextcloud Core.